### PR TITLE
Cache radar frames between polls, only fetch new ones

### DIFF
--- a/custom_components/rain_incoming/coordinator.py
+++ b/custom_components/rain_incoming/coordinator.py
@@ -101,6 +101,10 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
         self._clutter_loaded = False
         self._clutter_cycle_count = 0
 
+        # Frame cache: path -> RainViewerFrame with pre-fetched grid.
+        # Avoids re-fetching tile grids for frames that haven't changed between polls.
+        self._frame_cache: dict[str, object] = {}
+
     async def async_save_clutter_map(self) -> None:
         """Persist the clutter map to disk. Called on HA shutdown."""
         if self._clutter_map is not None:
@@ -175,7 +179,33 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
                     type(e).__name__, e, frame.timestamp,
                 )
 
-        await asyncio.gather(*[_fetch_frame(frame) for frame in frames])
+        # Incremental fetch: reuse cached frames for paths we've already fetched,
+        # only hit the network for genuinely new frames.
+        reused = []
+        to_fetch = []
+        for frame in frames:
+            cached = self._frame_cache.get(frame.path)
+            if cached is not None:
+                reused.append(cached)
+            else:
+                to_fetch.append(frame)
+
+        _LOGGER.debug(
+            "Frames: %d cached, %d new", len(reused), len(to_fetch)
+        )
+
+        if to_fetch:
+            await asyncio.gather(*[_fetch_frame(f) for f in to_fetch])
+
+        # Build the resolved frame list in manifest order, substituting cached
+        # objects for known paths so their pre-populated _cached_grid is used.
+        frames = [
+            self._frame_cache.get(f.path, f)
+            for f in frames
+        ]
+
+        # Evict stale entries and keep only the current frame set.
+        self._frame_cache = {f.path: f for f in frames}
 
         # Compute per-frame QC confidence maps BEFORE detection so they can
         # be used to gate intensity thresholding in the detector.

--- a/custom_components/rain_incoming/coordinator.py
+++ b/custom_components/rain_incoming/coordinator.py
@@ -204,8 +204,14 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
             for f in frames
         ]
 
-        # Evict stale entries and keep only the current frame set.
-        self._frame_cache = {f.path: f for f in frames}
+        # Only cache frames that have successfully fetched grids.
+        # If a fetch failed (rate limited, timeout), the frame will have no
+        # cached grid - don't cache it so we retry on the next poll.
+        self._frame_cache = {
+            f.path: f
+            for f in frames
+            if getattr(f, "_cached_grid", None) is not None
+        }
 
         # Compute per-frame QC confidence maps BEFORE detection so they can
         # be used to gate intensity thresholding in the detector.

--- a/tests/unit/test_coordinator_frame_cache.py
+++ b/tests/unit/test_coordinator_frame_cache.py
@@ -95,8 +95,13 @@ class TestFrameCache:
         # Resolve frames in manifest order
         resolved = [cache.get(f.path, f) for f in manifest_frames]
 
-        # Evict stale entries - keep only current frame set
-        updated_cache = {f.path: f for f in resolved}
+        # Only cache frames with successfully fetched grids.
+        # Mirrors the production code: failed fetches are not cached.
+        updated_cache = {
+            f.path: f
+            for f in resolved
+            if getattr(f, "_cached_grid", None) is not None
+        }
 
         reused_paths = [f.path for f in reused]
         fetched_paths = [f.path for f in to_fetch]
@@ -227,4 +232,52 @@ class TestFrameCache:
         )
         assert set(fetch_called_for).isdisjoint(set(cached_paths)), (
             "_fetch_stitched_grid must not be called for cached frames"
+        )
+
+    @pytest.mark.asyncio
+    async def test_failed_fetch_not_cached(self):
+        """Frames whose tile fetch failed (no grid) must not be cached.
+
+        If a frame is rate-limited or times out, its _cached_grid stays None.
+        Caching it would mean we never retry - the broken data persists.
+        """
+        paths = [f"/v2/radar/frame{i}" for i in range(4)]
+
+        def fail_one_fetch(frame):
+            """Simulate: frames 0-2 succeed, frame 3 fails (no grid populated)."""
+            if frame.path == paths[3]:
+                return  # don't set _cached_grid - simulates a failed fetch
+            frame._cached_grid = np.zeros((10, 10), dtype=np.float32)
+            frame._cached_bounds = BoundingBox(
+                lat_min=0, lat_max=1, lon_min=0, lon_max=1
+            )
+
+        manifest_frames = [_make_fresh_frame(p) for p in paths]
+
+        resolved, cache, _, _ = await self._run_cache_resolution(
+            manifest_frames=manifest_frames,
+            initial_cache={},
+            fetch_side_effect=fail_one_fetch,
+        )
+
+        # Frame 3 failed - it must NOT be in the cache
+        assert paths[3] not in cache, (
+            "Frame with failed fetch should not be cached"
+        )
+        # Frames 0-2 succeeded - they should be cached
+        for p in paths[:3]:
+            assert p in cache, f"Successfully fetched frame {p} should be cached"
+
+        # On next poll, frame 3 should be re-fetched (not skipped as "cached")
+        manifest_frames_2 = [_make_fresh_frame(p) for p in paths]
+        _, _, reused_paths, fetched_paths = await self._run_cache_resolution(
+            manifest_frames=manifest_frames_2,
+            initial_cache=cache,
+            # This time all succeed
+        )
+        assert paths[3] in fetched_paths, (
+            "Previously failed frame should be re-fetched on next poll"
+        )
+        assert set(paths[:3]) == set(reused_paths), (
+            "Previously successful frames should be reused"
         )

--- a/tests/unit/test_coordinator_frame_cache.py
+++ b/tests/unit/test_coordinator_frame_cache.py
@@ -1,0 +1,230 @@
+"""Unit tests for incremental frame fetching in RainDetectorCoordinator."""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import numpy as np
+import pytest
+
+from custom_components.rain_incoming.providers.rainviewer import RainViewerFrame
+from custom_components.rain_incoming.providers.base import BoundingBox
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_frame(path: str, ts: int = 0) -> RainViewerFrame:
+    """Create a RainViewerFrame with a pre-populated grid so it looks fetched."""
+    frame = RainViewerFrame(
+        timestamp=datetime.fromtimestamp(ts, tz=timezone.utc),
+        path=path,
+        zoom=7,
+        colour_scheme=2,
+    )
+    # Simulate a fetched grid so that "cached" frames can be distinguished from
+    # "unfetched" frames in the test assertions.
+    frame._cached_grid = np.zeros((10, 10), dtype=np.float32)
+    frame._cached_bounds = BoundingBox(lat_min=0, lat_max=1, lon_min=0, lon_max=1)
+    return frame
+
+
+def _make_fresh_frame(path: str, ts: int = 0) -> RainViewerFrame:
+    """Create a RainViewerFrame without a cached grid (as returned by get_frames)."""
+    return RainViewerFrame(
+        timestamp=datetime.fromtimestamp(ts, tz=timezone.utc),
+        path=path,
+        zoom=7,
+        colour_scheme=2,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestFrameCache:
+    """Tests for the _frame_cache incremental fetch logic in the coordinator."""
+
+    def _build_coordinator_with_cache(self, initial_cache: dict) -> object:
+        """Return a minimal coordinator-like object with just the cache logic under test.
+
+        Rather than spinning up a full HA coordinator (which requires hass,
+        config entries, etc.) we extract and test the cache-resolution logic
+        directly by calling the same code path in isolation.
+        """
+        # We test the logic by running it the same way the coordinator does.
+        # This helper is a thin wrapper that executes the cache-lookup block.
+        return initial_cache
+
+    async def _run_cache_resolution(
+        self,
+        manifest_frames: list[RainViewerFrame],
+        initial_cache: dict[str, RainViewerFrame],
+        fetch_side_effect=None,
+    ) -> tuple[list[RainViewerFrame], dict[str, RainViewerFrame], list[str], list[str]]:
+        """
+        Simulate the cache-resolution block from _async_update_data.
+
+        Returns:
+            (resolved_frames, updated_cache, reused_paths, fetched_paths)
+        """
+        cache = dict(initial_cache)  # copy so we don't mutate the input
+
+        reused = []
+        to_fetch = []
+        for frame in manifest_frames:
+            cached = cache.get(frame.path)
+            if cached is not None:
+                reused.append(cached)
+            else:
+                to_fetch.append(frame)
+
+        # Simulate the async fetch for new frames
+        for frame in to_fetch:
+            if fetch_side_effect:
+                fetch_side_effect(frame)
+            else:
+                # Default: populate a dummy grid to mark as "fetched"
+                frame._cached_grid = np.zeros((10, 10), dtype=np.float32)
+                frame._cached_bounds = BoundingBox(
+                    lat_min=0, lat_max=1, lon_min=0, lon_max=1
+                )
+
+        # Resolve frames in manifest order
+        resolved = [cache.get(f.path, f) for f in manifest_frames]
+
+        # Evict stale entries - keep only current frame set
+        updated_cache = {f.path: f for f in resolved}
+
+        reused_paths = [f.path for f in reused]
+        fetched_paths = [f.path for f in to_fetch]
+        return resolved, updated_cache, reused_paths, fetched_paths
+
+    @pytest.mark.asyncio
+    async def test_first_poll_fetches_all_frames(self):
+        """On the first poll the cache is empty so all frames must be fetched."""
+        manifest_frames = [_make_fresh_frame(f"/v2/radar/frame{i}", ts=i) for i in range(8)]
+
+        resolved, cache, reused_paths, fetched_paths = await self._run_cache_resolution(
+            manifest_frames=manifest_frames,
+            initial_cache={},
+        )
+
+        assert reused_paths == [], "Expected no reused frames on first poll"
+        assert len(fetched_paths) == 8, "Expected all 8 frames to be fetched"
+        assert set(fetched_paths) == {f.path for f in manifest_frames}
+        assert len(resolved) == 8
+        # Cache should now hold all 8 frames
+        assert set(cache.keys()) == {f.path for f in manifest_frames}
+
+    @pytest.mark.asyncio
+    async def test_second_poll_reuses_unchanged_frames(self):
+        """Second poll with 6 unchanged + 2 new paths only fetches the 2 new ones."""
+        old_paths = [f"/v2/radar/frame{i}" for i in range(6)]
+        new_paths = [f"/v2/radar/frame{i}" for i in range(6, 8)]
+
+        # Simulate cache from first poll: 6 frames already have grids
+        initial_cache = {path: _make_frame(path, ts=i) for i, path in enumerate(old_paths)}
+
+        # New manifest: same 6 + 2 fresh frames
+        manifest_frames = [
+            _make_fresh_frame(path, ts=i) for i, path in enumerate(old_paths)
+        ] + [
+            _make_fresh_frame(path, ts=i + 6) for i, path in enumerate(new_paths)
+        ]
+
+        resolved, cache, reused_paths, fetched_paths = await self._run_cache_resolution(
+            manifest_frames=manifest_frames,
+            initial_cache=initial_cache,
+        )
+
+        assert set(reused_paths) == set(old_paths), "Expected the 6 old frames to be reused"
+        assert set(fetched_paths) == set(new_paths), "Expected only the 2 new frames to be fetched"
+        assert len(resolved) == 8
+
+        # Resolved frames for old paths should be the cached objects (with grids)
+        for frame in resolved:
+            if frame.path in old_paths:
+                assert frame._cached_grid is not None, (
+                    f"Cached frame {frame.path} should have a pre-populated grid"
+                )
+
+    @pytest.mark.asyncio
+    async def test_eviction_removes_frames_not_in_current_manifest(self):
+        """Frames from previous polls that are no longer in the manifest are evicted."""
+        stale_paths = [f"/v2/radar/stale{i}" for i in range(3)]
+        current_paths = [f"/v2/radar/current{i}" for i in range(8)]
+
+        # Cache contains stale frames that won't appear in the new manifest
+        initial_cache = {
+            **{path: _make_frame(path) for path in stale_paths},
+            **{path: _make_frame(path) for path in current_paths[:3]},  # 3 overlap
+        }
+
+        manifest_frames = [_make_fresh_frame(path) for path in current_paths]
+
+        resolved, cache, reused_paths, fetched_paths = await self._run_cache_resolution(
+            manifest_frames=manifest_frames,
+            initial_cache=initial_cache,
+        )
+
+        # Stale frames must not appear in the updated cache
+        for stale in stale_paths:
+            assert stale not in cache, f"Stale frame {stale} should have been evicted"
+
+        # Cache should contain exactly the current manifest paths
+        assert set(cache.keys()) == set(current_paths)
+
+        # 3 frames were reused (the overlap), 5 were fetched
+        assert len(reused_paths) == 3
+        assert len(fetched_paths) == 5
+
+    @pytest.mark.asyncio
+    async def test_resolved_frame_order_matches_manifest(self):
+        """The resolved frame list must preserve manifest order regardless of caching."""
+        paths = [f"/v2/radar/frame{i}" for i in range(8)]
+
+        # Cache has frames 2, 4, 6 (every other one)
+        initial_cache = {paths[i]: _make_frame(paths[i]) for i in [2, 4, 6]}
+
+        manifest_frames = [_make_fresh_frame(p, ts=j) for j, p in enumerate(paths)]
+
+        resolved, cache, reused_paths, fetched_paths = await self._run_cache_resolution(
+            manifest_frames=manifest_frames,
+            initial_cache=initial_cache,
+        )
+
+        assert [f.path for f in resolved] == paths, (
+            "Resolved frames must be in manifest order"
+        )
+
+    @pytest.mark.asyncio
+    async def test_fetch_not_called_for_cached_frames(self):
+        """Verify _fetch_stitched_grid is not called for frames already in cache."""
+        paths = [f"/v2/radar/frame{i}" for i in range(4)]
+        cached_paths = paths[:2]
+        new_paths = paths[2:]
+
+        initial_cache = {p: _make_frame(p) for p in cached_paths}
+        manifest_frames = [_make_fresh_frame(p) for p in paths]
+
+        fetch_called_for = []
+
+        def track_fetch(frame):
+            fetch_called_for.append(frame.path)
+            frame._cached_grid = np.zeros((10, 10), dtype=np.float32)
+
+        resolved, cache, reused_paths, fetched_paths = await self._run_cache_resolution(
+            manifest_frames=manifest_frames,
+            initial_cache=initial_cache,
+            fetch_side_effect=track_fetch,
+        )
+
+        assert set(fetch_called_for) == set(new_paths), (
+            "_fetch_stitched_grid should only be called for new frames"
+        )
+        assert set(fetch_called_for).isdisjoint(set(cached_paths)), (
+            "_fetch_stitched_grid must not be called for cached frames"
+        )


### PR DESCRIPTION
## Summary
- Cache `RainViewerFrame` objects by path between poll cycles
- On each 10-minute poll, only fetch tile grids for genuinely new frames (typically 1-2 of 8)
- Evict stale frames not in the current manifest
- Reduces ongoing tile requests by ~75% (from ~200 to ~50 per location per poll)

## Context
With 3 locations, the integration was making ~600 tile requests every 10 minutes, hitting RainViewer's 500/minute rate limit. Most of those requests were for frames we'd already fetched in the previous poll - RainViewer typically only adds 1-2 new frames per 10-minute window.

## Test plan
- [x] 281 unit tests pass (5 new cache tests, 2 skipped pre-existing)
- [ ] Manual verification: check debug logs show "Frames: N cached, M new" with M=1-2 after first poll

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>