### PR TITLE
Expose composable rendering pipeline

### DIFF
--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -555,6 +555,83 @@ async def render_composite(
     return _render_sync(map_crop, radar_resized, lat, lon, vp.map_zoom, radius_km, output_size)
 
 
+# --- Public composable API ---
+# These functions expose the rendering pipeline as independent building blocks.
+# Production code uses render_animated_composite() which calls all of them.
+# Tests can call them individually for isolated assertions.
+
+
+async def fetch_map_crop(
+    session: aiohttp.ClientSession,
+    lat: float,
+    lon: float,
+    radius_km: int,
+    output_size: int = 640,
+) -> Image.Image:
+    """Fetch CartoDB map tiles for a location and radius. Returns a cropped PIL image."""
+    vp = _ViewportParams(lat, lon, radius_km, output_size)
+    return await _fetch_map_crop(session, vp, output_size)
+
+
+async def fetch_radar_overlays(
+    session: aiohttp.ClientSession,
+    lat: float,
+    lon: float,
+    radius_km: int,
+    frame_paths: list[str],
+    output_size: int = 640,
+) -> list[Image.Image]:
+    """Fetch radar tiles for each frame path. Returns a list of RGBA PIL images."""
+    vp = _ViewportParams(lat, lon, radius_km, output_size)
+    return list(await asyncio.gather(*[
+        _fetch_radar_overlay(session, vp, fp, output_size) for fp in frame_paths
+    ]))
+
+
+def composite_frames(
+    background: Image.Image,
+    radar_overlays: list[Image.Image],
+    lat: float,
+    lon: float,
+    radius_km: int,
+    output_size: int = 640,
+    *,
+    frame_timestamps: list[datetime] | None = None,
+    tz_name: str | None = None,
+    confidence_maps: list[np.ndarray] | None = None,
+) -> list[Image.Image]:
+    """Composite radar overlays over a background image. Returns a list of frames."""
+    vp = _ViewportParams(lat, lon, radius_km, output_size)
+    timestamps = frame_timestamps or [None] * len(radar_overlays)
+    frames: list[Image.Image] = []
+    for i, radar_resized in enumerate(radar_overlays):
+        ts = timestamps[i] if i < len(timestamps) else None
+        conf_map = confidence_maps[i] if confidence_maps and i < len(confidence_maps) else None
+        frame_img = _composite_single_frame(
+            background, radar_resized, lat, lon, vp.map_zoom, radius_km, output_size,
+            timestamp=ts, tz_name=tz_name,
+            confidence_map=conf_map,
+        )
+        frames.append(frame_img)
+    return frames
+
+
+def render_gif(
+    frames: list[Image.Image],
+    frame_duration_ms: int = 500,
+) -> bytes:
+    """Encode PIL frames to animated GIF bytes."""
+    if not frames:
+        blank = Image.new("RGB", (100, 100), (0, 0, 0))
+        buf = BytesIO()
+        blank.save(buf, format="GIF")
+        return buf.getvalue()
+    return _render_gif_sync(frames, frame_duration_ms)
+
+
+# --- High-level convenience function (used by image.py) ---
+
+
 async def render_animated_composite(
     lat: float,
     lon: float,
@@ -571,40 +648,22 @@ async def render_animated_composite(
 ) -> bytes:
     """Render an animated GIF compositing multiple radar frames over a static map.
 
-    Parameters
-    ----------
-    frame_timestamps: optional list of datetimes matching frame_paths, used for
-        overlaying a timestamp on each frame.
-    confidence_maps: optional per-frame confidence arrays from the QC pipeline.
-        Each array is float32 (H, W), values 0-1. Applied as an alpha multiplier
-        to dim low-confidence pixels.
-    session: an aiohttp.ClientSession for fetching tiles.
-    run_in_executor: optional callable (e.g. hass.async_add_executor_job)
-        to offload CPU-bound GIF assembly. If None, rendering runs inline.
+    Convenience function that calls fetch_map_crop, fetch_radar_overlays,
+    composite_frames, and render_gif in sequence.
     """
-    vp = _ViewportParams(lat, lon, radius_km, output_size)
-
-    # Fetch map tiles once - they're the same for every frame
-    map_crop = await _fetch_map_crop(session, vp, output_size)
-
-    # Fetch all radar overlays in parallel
-    radar_overlays = await asyncio.gather(*[
-        _fetch_radar_overlay(session, vp, fp, output_size) for fp in frame_paths
-    ])
-
-    timestamps = frame_timestamps or [None] * len(frame_paths)
-
-    # Composite each frame (CPU-bound but fast - no I/O)
-    frames: list[Image.Image] = []
-    for i, radar_resized in enumerate(radar_overlays):
-        ts = timestamps[i] if i < len(timestamps) else None
-        conf_map = confidence_maps[i] if confidence_maps and i < len(confidence_maps) else None
-        frame_img = _composite_single_frame(
-            map_crop, radar_resized, lat, lon, vp.map_zoom, radius_km, output_size,
-            timestamp=ts, tz_name=tz_name,
-            confidence_map=conf_map,
-        )
-        frames.append(frame_img)
+    map_crop = await fetch_map_crop(session, lat, lon, radius_km, output_size)
+    radar_overlays = await fetch_radar_overlays(
+        session, lat, lon, radius_km, frame_paths, output_size
+    )
+    frames = composite_frames(
+        background=map_crop,
+        radar_overlays=radar_overlays,
+        lat=lat, lon=lon, radius_km=radius_km,
+        output_size=output_size,
+        frame_timestamps=frame_timestamps,
+        tz_name=tz_name,
+        confidence_maps=confidence_maps,
+    )
 
     if not frames:
         # Shouldn't happen, but return a blank GIF if no frames

--- a/tests/unit/radar/test_composite_radar_only.py
+++ b/tests/unit/radar/test_composite_radar_only.py
@@ -1,0 +1,134 @@
+"""Unit tests for composable rendering pipeline.
+
+The rendering pipeline exposes independent building blocks:
+- fetch_map_crop(): fetches CartoDB map tiles for a location/radius
+- fetch_radar_overlays(): fetches RainViewer radar tiles for frame paths
+- composite_frames(): composites radar over a background image
+- render_gif(): encodes PIL frames to animated GIF bytes
+
+Tests can compose these directly for clean, fast assertions without
+needing the full E2E stack.
+"""
+from __future__ import annotations
+
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from custom_components.rain_incoming.radar.composite import (
+    composite_frames,
+    fetch_map_crop,
+    fetch_radar_overlays,
+    render_animated_composite,
+    render_gif,
+)
+
+
+def _make_mock_session():
+    """Create a mock aiohttp session that returns valid tile PNGs."""
+    session = MagicMock()
+
+    async def _mock_get(url, **kwargs):
+        resp = MagicMock()
+        if "tilecache.rainviewer.com" in url:
+            img = Image.new("RGBA", (256, 256), (0, 0, 0, 0))
+        else:
+            img = Image.new("RGBA", (256, 256), (128, 128, 128, 255))
+        buf = BytesIO()
+        img.save(buf, "PNG")
+        buf.seek(0)
+        resp.read = AsyncMock(return_value=buf.getvalue())
+        resp.status = 200
+        resp.release = MagicMock()
+        return resp
+
+    session.get = AsyncMock(side_effect=_mock_get)
+    return session
+
+
+def _count_non_black_pixels(gif_bytes: bytes) -> int:
+    """Count pixels that aren't black in the last frame of a GIF."""
+    img = Image.open(BytesIO(gif_bytes))
+    if hasattr(img, "n_frames") and img.n_frames > 1:
+        img.seek(img.n_frames - 1)
+    arr = np.array(img.convert("RGB"))
+    return int((arr.max(axis=2) > 10).sum())
+
+
+class TestComposableRenderingPipeline:
+    """Test the composable building blocks of the rendering pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_radar_only_dry_data_is_mostly_black(self):
+        """Radar overlays with no precipitation composited over black
+        should produce a mostly-black image (only annotations visible)."""
+        session = _make_mock_session()
+
+        overlays = await fetch_radar_overlays(
+            session=session, lat=-33.701, lon=151.209, radius_km=128,
+            frame_paths=["/v2/radar/test_frame"],
+        )
+        assert len(overlays) == 1
+
+        background = Image.new("RGBA", (640, 640), (0, 0, 0, 255))
+        frames = composite_frames(
+            background=background, radar_overlays=overlays,
+            lat=-33.701, lon=151.209, radius_km=128,
+        )
+        gif_bytes = render_gif(frames)
+
+        non_black = _count_non_black_pixels(gif_bytes)
+        total = 640 * 640
+        assert non_black / total < 0.05, (
+            f"Radar-only dry render has {non_black / total:.1%} non-black pixels"
+        )
+
+    @pytest.mark.asyncio
+    async def test_map_background_is_mostly_non_black(self):
+        """Map crop should contain visible map content."""
+        session = _make_mock_session()
+        map_crop = await fetch_map_crop(
+            session=session, lat=-33.701, lon=151.209, radius_km=128,
+        )
+        arr = np.array(map_crop.convert("RGB"))
+        non_black = (arr.max(axis=2) > 10).sum()
+        total = arr.shape[0] * arr.shape[1]
+        assert non_black / total > 0.5, "Map background should be mostly non-black"
+
+    @pytest.mark.asyncio
+    async def test_full_composite_includes_map(self):
+        """render_animated_composite produces a full map+radar image."""
+        session = _make_mock_session()
+        gif_bytes = await render_animated_composite(
+            lat=-33.701, lon=151.209, radius_km=128,
+            frame_paths=["/v2/radar/test_frame"],
+            session=session,
+        )
+        non_black = _count_non_black_pixels(gif_bytes)
+        total = 640 * 640
+        assert non_black / total > 0.5, "Full composite should include map"
+
+    @pytest.mark.asyncio
+    async def test_render_gif_produces_valid_gif(self):
+        """render_gif returns valid GIF bytes."""
+        frame = Image.new("RGB", (100, 100), (255, 0, 0))
+        gif_bytes = render_gif([frame])
+        assert gif_bytes[:6] in (b"GIF87a", b"GIF89a")
+
+    @pytest.mark.asyncio
+    async def test_composite_frames_preserves_frame_count(self):
+        """composite_frames returns one frame per radar overlay."""
+        session = _make_mock_session()
+        overlays = await fetch_radar_overlays(
+            session=session, lat=-33.701, lon=151.209, radius_km=128,
+            frame_paths=["/v2/radar/f1", "/v2/radar/f2", "/v2/radar/f3"],
+        )
+        background = Image.new("RGBA", (640, 640), (0, 0, 0, 255))
+        frames = composite_frames(
+            background=background, radar_overlays=overlays,
+            lat=-33.701, lon=151.209, radius_km=128,
+        )
+        assert len(frames) == 3


### PR DESCRIPTION
## Summary
Extract four public functions from the rendering pipeline:
- `fetch_map_crop()` - fetch CartoDB map tiles
- `fetch_radar_overlays()` - fetch RainViewer radar tiles  
- `composite_frames()` - composite radar over any background
- `render_gif()` - encode frames to animated GIF

`render_animated_composite()` now delegates to these building blocks.

## Why
The old monolithic render function was untestable in isolation - checking for precipitation pixels in the output required the full map background, and CartoDB vegetation greens matched precipitation colour thresholds causing false positives.

Now tests can compose steps independently - e.g. composite radar over black for clean assertions. No boolean flags, just composition.

## Test plan
- [x] 268 unit/integration tests pass (5 new composable pipeline tests)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>