### PR TITLE
Align polling to fixed schedule (01/11/21/31/41/51)

### DIFF
--- a/custom_components/rain_incoming/coordinator.py
+++ b/custom_components/rain_incoming/coordinator.py
@@ -12,6 +12,25 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
+# Aligned polling schedule: minutes past the hour when we poll.
+# RainViewer updates on the 0s (00, 10, 20...), so +1 minute gives them
+# time to publish. Polling at these fixed times ensures fresh data
+# regardless of when HA started.
+_POLL_MINUTES = (1, 11, 21, 31, 41, 51)
+
+
+def next_aligned_poll_time(now: datetime) -> datetime:
+    """Return the next datetime at minute 01/11/21/31/41/51, second 00."""
+    for m in _POLL_MINUTES:
+        candidate = now.replace(minute=m, second=0, microsecond=0)
+        if candidate > now:
+            return candidate
+    # All slots in this hour have passed - wrap to next hour, first slot
+    next_hour = (now.replace(minute=0, second=0, microsecond=0)
+                 + timedelta(hours=1))
+    return next_hour.replace(minute=_POLL_MINUTES[0])
+
+
 from .const import (
     BACKOFF_BASE_SECONDS,
     BACKOFF_MAX_SECONDS,
@@ -95,11 +114,16 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
     """Fetches radar frames, runs detection, and manages backoff on failure."""
 
     def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
+        # Set initial interval to reach the next aligned poll time
+        now = datetime.now(timezone.utc)
+        next_poll = next_aligned_poll_time(now)
+        initial_interval = max(next_poll - now, timedelta(seconds=10))
+
         super().__init__(
             hass,
             _LOGGER,
             name="rain_incoming",
-            update_interval=timedelta(seconds=POLL_INTERVAL_SECONDS),
+            update_interval=initial_interval,
         )
         self._entry = entry
         self._provider = RainViewerProvider()
@@ -330,6 +354,13 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
 
         self._consecutive_failures = 0
         self.last_update_success_time = datetime.now(timezone.utc)
+
+        # Schedule the next poll at the next aligned time
+        now = datetime.now(timezone.utc)
+        next_poll = next_aligned_poll_time(now)
+        self.update_interval = max(next_poll - now, timedelta(seconds=10))
+        _LOGGER.debug("Next poll at %s (in %ds)", next_poll.strftime("%H:%M"), self.update_interval.total_seconds())
+
         return result
 
     async def _fetch_with_backoff(self, lat: float, lon: float):

--- a/tests/unit/test_aligned_polling.py
+++ b/tests/unit/test_aligned_polling.py
@@ -1,0 +1,74 @@
+"""Tests for aligned polling schedule.
+
+TDD: these tests are written FIRST, before the implementation.
+
+Polling should align to minutes 01, 11, 21, 31, 41, 51 past the hour
+so that data is always ~1 minute behind RainViewer's 10-minute updates,
+regardless of when HA started.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from custom_components.rain_incoming.coordinator import next_aligned_poll_time
+
+
+class TestNextAlignedPollTime:
+    """next_aligned_poll_time returns the next time at minute 01/11/21/31/41/51."""
+
+    def test_just_after_the_hour(self):
+        """At 10:00:30, next poll should be 10:01:00."""
+        now = datetime(2026, 4, 10, 10, 0, 30, tzinfo=timezone.utc)
+        result = next_aligned_poll_time(now)
+        assert result == datetime(2026, 4, 10, 10, 1, 0, tzinfo=timezone.utc)
+
+    def test_at_01_should_return_11(self):
+        """At 10:01:00 exactly, next poll should be 10:11:00."""
+        now = datetime(2026, 4, 10, 10, 1, 0, tzinfo=timezone.utc)
+        result = next_aligned_poll_time(now)
+        assert result == datetime(2026, 4, 10, 10, 11, 0, tzinfo=timezone.utc)
+
+    def test_mid_window(self):
+        """At 10:05:00, next poll should be 10:11:00."""
+        now = datetime(2026, 4, 10, 10, 5, 0, tzinfo=timezone.utc)
+        result = next_aligned_poll_time(now)
+        assert result == datetime(2026, 4, 10, 10, 11, 0, tzinfo=timezone.utc)
+
+    def test_at_51_should_wrap_to_next_hour(self):
+        """At 10:51:00 exactly, next poll should be 11:01:00."""
+        now = datetime(2026, 4, 10, 10, 51, 0, tzinfo=timezone.utc)
+        result = next_aligned_poll_time(now)
+        assert result == datetime(2026, 4, 10, 11, 1, 0, tzinfo=timezone.utc)
+
+    def test_at_55_should_wrap_to_next_hour(self):
+        """At 10:55:00, next poll should be 11:01:00."""
+        now = datetime(2026, 4, 10, 10, 55, 0, tzinfo=timezone.utc)
+        result = next_aligned_poll_time(now)
+        assert result == datetime(2026, 4, 10, 11, 1, 0, tzinfo=timezone.utc)
+
+    def test_at_59_should_wrap_to_next_hour(self):
+        """At 23:59:30, next poll should be 00:01:00 next day."""
+        now = datetime(2026, 4, 10, 23, 59, 30, tzinfo=timezone.utc)
+        result = next_aligned_poll_time(now)
+        assert result == datetime(2026, 4, 11, 0, 1, 0, tzinfo=timezone.utc)
+
+    def test_returns_utc(self):
+        """Result should always be UTC."""
+        now = datetime(2026, 4, 10, 10, 5, 0, tzinfo=timezone.utc)
+        result = next_aligned_poll_time(now)
+        assert result.tzinfo == timezone.utc
+
+    def test_seconds_until_next_poll(self):
+        """At 10:09:45, next poll is 10:11:00 = 75 seconds away."""
+        now = datetime(2026, 4, 10, 10, 9, 45, tzinfo=timezone.utc)
+        result = next_aligned_poll_time(now)
+        delta = (result - now).total_seconds()
+        assert delta == 75.0
+
+    def test_at_exactly_aligned_time_returns_next_slot(self):
+        """At 10:21:00.000, should return 10:31:00 not 10:21:00."""
+        now = datetime(2026, 4, 10, 10, 21, 0, tzinfo=timezone.utc)
+        result = next_aligned_poll_time(now)
+        assert result == datetime(2026, 4, 10, 10, 31, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
Poll at minutes 01, 11, 21, 31, 41, 51 past each hour instead of every 10 minutes from HA start time.

RainViewer updates every 10 minutes on the 0s. Polling at +1 minute gives them time to publish while keeping data as fresh as possible. No more permanent lag from unlucky HA start times.

## How it works
- `next_aligned_poll_time(now)` computes the next slot
- Coordinator sets `update_interval` dynamically after each poll
- Initial interval targets the first aligned slot after startup

## Test plan
- [x] 277 unit/integration tests pass (9 new polling schedule tests)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>