### PR TITLE
Add BOM-style labels to animated radar GIF

### DIFF
--- a/custom_components/rain_incoming/image.py
+++ b/custom_components/rain_incoming/image.py
@@ -85,6 +85,7 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
 
         session = async_get_clientsession(self.hass)
         conf_maps = self.coordinator.confidence_maps or None
+        location_name = data.get(CONF_LOCATION_NAME) or None
         self._cached_image = await render_animated_composite(
             lat=lat,
             lon=lon,
@@ -94,6 +95,7 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
             frame_timestamps=local_timestamps,
             tz_name=self.hass.config.time_zone,
             confidence_maps=conf_maps,
+            location_name=location_name,
             session=session,
             run_in_executor=self.hass.async_add_executor_job,
         )

--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -228,16 +228,43 @@ async def _fetch_map_tile(
     return tile
 
 
-def _draw_timestamp(img: Image.Image, timestamp: datetime, tz_name: str | None = None) -> None:
-    """Draw a timestamp with date in the bottom-left corner."""
+def build_frame_label(
+    timestamp: datetime | None,
+    tz_name: str | None,
+    radius_km: int,
+    location_name: str | None = None,
+) -> str:
+    """Build the BOM-style label string for a GIF frame.
+
+    Format: "Location  DD/MM/YY  HH:MM TZ  Rangekm"
+    Location is omitted if not set.
+    """
+    parts = []
+    if location_name:
+        parts.append(location_name)
+    if timestamp is not None:
+        tz_label = timestamp.strftime("%Z") or tz_name or "UTC"
+        parts.append(timestamp.strftime("%d/%m/%y"))
+        parts.append(timestamp.strftime(f"%H:%M {tz_label}"))
+    parts.append(f"{radius_km}km")
+    return "  ".join(parts)
+
+
+def _draw_frame_label(
+    img: Image.Image,
+    timestamp: datetime | None,
+    tz_name: str | None,
+    radius_km: int,
+    location_name: str | None = None,
+) -> None:
+    """Draw the BOM-style label in the bottom-left corner of a frame."""
+    label = build_frame_label(timestamp, tz_name, radius_km, location_name)
     draw = ImageDraw.Draw(img)
     try:
         font = ImageFont.load_default(size=16)
     except TypeError:
         font = ImageFont.load_default()
 
-    tz_label = timestamp.strftime("%Z") or tz_name or "UTC"
-    label = timestamp.strftime(f"%d %b %Y  %H:%M {tz_label}")
     bbox = font.getbbox(label)
     tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
     padding = 8
@@ -263,6 +290,7 @@ def _composite_single_frame(
     timestamp: datetime | None = None,
     tz_name: str | None = None,
     confidence_map: np.ndarray | None = None,
+    location_name: str | None = None,
 ) -> Image.Image:
     """CPU-bound rendering: composite map + radar, draw overlays. Returns RGBA Image.
 
@@ -310,8 +338,7 @@ def _composite_single_frame(
     draw_range_rings(composite, cx, cy, radius_px, radius_km)
     draw_crosshair(composite, cx, cy)
 
-    if timestamp is not None:
-        _draw_timestamp(composite, timestamp, tz_name)
+    _draw_frame_label(composite, timestamp, tz_name, radius_km, location_name)
 
     return composite
 
@@ -599,6 +626,7 @@ def composite_frames(
     frame_timestamps: list[datetime] | None = None,
     tz_name: str | None = None,
     confidence_maps: list[np.ndarray] | None = None,
+    location_name: str | None = None,
 ) -> list[Image.Image]:
     """Composite radar overlays over a background image. Returns a list of frames."""
     vp = _ViewportParams(lat, lon, radius_km, output_size)
@@ -611,6 +639,7 @@ def composite_frames(
             background, radar_resized, lat, lon, vp.map_zoom, radius_km, output_size,
             timestamp=ts, tz_name=tz_name,
             confidence_map=conf_map,
+            location_name=location_name,
         )
         frames.append(frame_img)
     return frames
@@ -643,6 +672,7 @@ async def render_animated_composite(
     frame_timestamps: list[datetime] | None = None,
     tz_name: str | None = None,
     confidence_maps: list[np.ndarray] | None = None,
+    location_name: str | None = None,
     session: aiohttp.ClientSession,
     run_in_executor: object = None,
 ) -> bytes:
@@ -663,6 +693,7 @@ async def render_animated_composite(
         frame_timestamps=frame_timestamps,
         tz_name=tz_name,
         confidence_maps=confidence_maps,
+        location_name=location_name,
     )
 
     if not frames:

--- a/tests/unit/radar/test_gif_labels.py
+++ b/tests/unit/radar/test_gif_labels.py
@@ -1,0 +1,68 @@
+"""Tests for BOM-style GIF labels.
+
+TDD: these tests are written FIRST, before the implementation.
+
+The label at the bottom of each GIF frame should show:
+  Location  DD/MM/YY  HH:MM TZ  Range
+
+Examples:
+  "Sydney  10/04/26  20:40 AEST  128km"
+  "10/04/26  20:40 UTC  64km"  (no location name set)
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from io import BytesIO
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from custom_components.rain_incoming.radar.composite import build_frame_label
+
+
+class TestBuildFrameLabel:
+    """Test the label string builder."""
+
+    def test_full_label_with_location(self):
+        ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+        label = build_frame_label(
+            timestamp=ts, tz_name="UTC", radius_km=128, location_name="Sydney",
+        )
+        assert label == "Sydney  10/04/26  20:40 UTC  128km"
+
+    def test_label_without_location(self):
+        ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+        label = build_frame_label(
+            timestamp=ts, tz_name="UTC", radius_km=64,
+        )
+        assert label == "10/04/26  20:40 UTC  64km"
+
+    def test_label_with_local_timezone(self):
+        import zoneinfo
+        tz = zoneinfo.ZoneInfo("Australia/Sydney")
+        ts = datetime(2026, 4, 10, 9, 40, 0, tzinfo=tz)
+        label = build_frame_label(
+            timestamp=ts, tz_name="Australia/Sydney", radius_km=256,
+            location_name="Lake Margaret",
+        )
+        # strftime %Z on zoneinfo gives "AEST" for +10
+        tz_str = ts.strftime("%Z") or "AEST"
+        assert "Lake Margaret" in label
+        assert "10/04/26" in label
+        assert "09:40" in label
+        assert "256km" in label
+
+    def test_label_with_512km(self):
+        ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+        label = build_frame_label(
+            timestamp=ts, tz_name="UTC", radius_km=512, location_name="Babinda",
+        )
+        assert label == "Babinda  10/04/26  20:40 UTC  512km"
+
+    def test_no_timestamp_returns_range_only(self):
+        label = build_frame_label(
+            timestamp=None, tz_name=None, radius_km=128, location_name="Sydney",
+        )
+        assert "Sydney" in label
+        assert "128km" in label


### PR DESCRIPTION
## Summary
Each GIF frame now shows a BOM-inspired label: `Location  DD/MM/YY  HH:MM TZ  Rangekm`

Examples:
- `Sydney  10/04/26  20:40 AEST  128km`
- `10/04/26  20:40 UTC  64km` (no location name set)

Location name is pulled from the integration config when set.

## Changes
- `build_frame_label()` - pure function that builds the label string (easy to test)
- `_draw_frame_label()` - replaces old `_draw_timestamp()` with richer format
- `composite_frames()` and `render_animated_composite()` accept `location_name`
- `image.py` passes `location_name` from config through to rendering

## Test plan
- [x] 273 unit/integration tests pass (5 new label tests)
- [ ] Manual: verify labels render correctly in dev HA

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>