### PR TITLE
Fix deprecated asyncio.get_event_loop() in tests

### DIFF
--- a/tests/unit/providers/test_open_meteo.py
+++ b/tests/unit/providers/test_open_meteo.py
@@ -33,29 +33,26 @@ def _make_mock_session(response_json=None, status=200, raise_exc=None):
 
 
 class TestFetchPrecipitationNow:
-    def test_returns_precipitation_value(self):
+    @pytest.mark.asyncio
+    async def test_returns_precipitation_value(self):
         """Should extract precipitation from a valid API response."""
         session = _make_mock_session(
             response_json={"current": {"precipitation": 0.5, "time": "2026-04-08T10:00"}}
         )
-        result = asyncio.get_event_loop().run_until_complete(
-            fetch_precipitation_now(-33.7, 151.2, session)
-        )
+        result = await fetch_precipitation_now(-33.7, 151.2, session)
         assert result == 0.5
 
-    def test_returns_none_on_network_error(self):
+    @pytest.mark.asyncio
+    async def test_returns_none_on_network_error(self):
         """Network timeout should return None (fail open)."""
         session = _make_mock_session(raise_exc=asyncio.TimeoutError())
-        result = asyncio.get_event_loop().run_until_complete(
-            fetch_precipitation_now(-33.7, 151.2, session)
-        )
+        result = await fetch_precipitation_now(-33.7, 151.2, session)
         assert result is None
 
-    def test_returns_none_on_invalid_json(self):
+    @pytest.mark.asyncio
+    async def test_returns_none_on_invalid_json(self):
         """Garbage response (missing expected keys) should return None."""
         session = _make_mock_session(response_json={"garbage": True})
-        result = asyncio.get_event_loop().run_until_complete(
-            fetch_precipitation_now(-33.7, 151.2, session)
-        )
+        result = await fetch_precipitation_now(-33.7, 151.2, session)
         # "current" key is missing, so .get("current", {}).get("precipitation") -> None
         assert result is None

--- a/tests/unit/test_stale_image.py
+++ b/tests/unit/test_stale_image.py
@@ -48,7 +48,8 @@ def _make_entry():
 class TestStaleImageHandling:
     """Image entity returns cached image when coordinator has no fresh data."""
 
-    def test_returns_cached_image_when_coordinator_has_no_new_data(self):
+    @pytest.mark.asyncio
+    async def test_returns_cached_image_when_coordinator_has_no_new_data(self):
         """After a successful render, if coordinator.latest_frame_path becomes
         None (failed fetch), async_image should return the cached image."""
         coord = _make_coordinator(latest_frame_path=None)
@@ -60,20 +61,19 @@ class TestStaleImageHandling:
         entity._cached_frame_path = "/v2/radar/old"
 
         # Coordinator has no new data (failed fetch)
-        import asyncio
-        result = asyncio.get_event_loop().run_until_complete(entity.async_image())
+        result = await entity.async_image()
         assert result == b"GIF89a_previous_render", (
             "Should return cached image when coordinator has no fresh data"
         )
 
-    def test_returns_placeholder_when_no_cache_and_no_data(self):
+    @pytest.mark.asyncio
+    async def test_returns_placeholder_when_no_cache_and_no_data(self):
         """On first load with no data, return a placeholder image (not None/broken)."""
         coord = _make_coordinator(latest_frame_path=None)
         entry = _make_entry()
         entity = RadarImageEntity(coord, entry, 128)
 
-        import asyncio
-        result = asyncio.get_event_loop().run_until_complete(entity.async_image())
+        result = await entity.async_image()
         assert result is not None, "Should return placeholder, not None (causes broken image icon)"
         assert len(result) > 100, "Placeholder should be a valid image"
 


### PR DESCRIPTION
## Summary

- Converts 5 sync test functions that used `asyncio.get_event_loop().run_until_complete()` to proper `async`/`await` form with `@pytest.mark.asyncio`
- Affected files: `tests/unit/test_stale_image.py` (2 call sites) and `tests/unit/providers/test_open_meteo.py` (3 call sites)
- `asyncio.get_event_loop()` is deprecated since Python 3.10 and raises `DeprecationWarning` in 3.12 when called without a running loop - which is always the case in these sync test functions

## Test plan

- [x] Targeted tests pass with `-W error::DeprecationWarning` (no warnings promoted to errors)
- [x] Full unit + integration suite passes (289 tests)
- [x] No assertions changed - mechanical migration only

🤖 Generated with [Claude Code](https://claude.com/claude-code)