### PR TITLE
Fix two lying assertions that tested nothing

### DIFF
--- a/tests/integration/test_sensors.py
+++ b/tests/integration/test_sensors.py
@@ -121,20 +121,26 @@ async def test_image_entity_created(hass: HomeAssistant, mock_entry, entity_id):
 
 @pytest.mark.asyncio
 async def test_image_entity_content_type_is_gif(hass: HomeAssistant, mock_entry):
+    """All radar image entities must serve image/gif so the HA frontend animates the loop."""
     await _setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
-    entity = hass.data[DOMAIN][mock_entry.entry_id]
-    # Get the image entity from the entity registry
-    from homeassistant.helpers.entity_component import EntityComponent
+
     from homeassistant.components.image import DOMAIN as IMAGE_DOMAIN
-    component: EntityComponent = hass.data.get("entity_components", {}).get(IMAGE_DOMAIN)
-    if component is not None:
-        entities = [e for e in component.entities if "radar" in e.entity_id]
-        for entity in entities:
-            assert entity.content_type == "image/gif"
-    else:
-        # Fallback: check via state attributes
-        state = hass.states.get("image.rain_incoming_radar_128km")
-        assert state is not None
+    from homeassistant.helpers.entity_component import EntityComponent
+
+    component: EntityComponent | None = hass.data.get("entity_components", {}).get(IMAGE_DOMAIN)
+    if component is None:
+        pytest.fail(
+            "entity_components[image] not found in hass.data after integration setup - "
+            "cannot verify content_type"
+        )
+
+    radar_entities = [e for e in component.entities if "radar" in e.entity_id]
+    assert radar_entities, "No radar image entities found after integration setup"
+
+    for entity in radar_entities:
+        assert entity.content_type == "image/gif", (
+            f"{entity.entity_id} has content_type={entity.content_type!r}, expected 'image/gif'"
+        )
 
 
 # --- strings.json ---

--- a/tests/unit/test_coordinator_rate_limit.py
+++ b/tests/unit/test_coordinator_rate_limit.py
@@ -394,8 +394,9 @@ async def test_recovery_after_total_rate_limit(hass: HomeAssistant):
         with pytest.raises(UpdateFailed):
             await coordinator._async_update_data()
 
-    # Coordinator internal state should not have been poisoned
-    assert coordinator._consecutive_failures == 0 or True  # no strict requirement here
+    # Poll 1 fails at the tile-fetch level (not via _fetch_with_backoff), so the
+    # backoff counter must remain untouched at its initial value of zero.
+    assert coordinator._consecutive_failures == 0
 
     # --- Poll 2: full recovery ---
     frames_poll2 = [_make_frame(base_ts + (i + 4) * 600) for i in range(4)]


### PR DESCRIPTION
## Summary

Two tests in the test suite were lying - they appeared to assert something but actually tested nothing.

**Fix 1: `test_coordinator_rate_limit.py:398` - remove `or True`**

The assertion `assert coordinator._consecutive_failures == 0 or True` is permanently true regardless of the actual value. Removed the `or True` to make it a real assertion.

The check is valid: poll 1 fails at the tile-fetch level (all 429s hit `_fetch_stitched_grid`, not `_fetch_with_backoff`), so `_consecutive_failures` is never incremented and must remain at its initial value of 0. Asserting this confirms the coordinator's internal state isn't poisoned by the failure path.

Verified the test now fails when production code sets `_consecutive_failures = 1` at init.

**Fix 2: `test_sensors.py` - replace silent `else` branch with `pytest.fail()`**

The test `test_image_entity_content_type_is_gif` had an `if component is not None` guard with a fallback to `assert state is not None` - a completely different (and weaker) assertion. If `entity_components[image]` was ever None, the real content_type check was silently skipped.

Replaced the fallback with `pytest.fail()` so the test always either asserts `content_type == "image/gif"` or fails explicitly. Also added an assertion that at least one radar entity was found.

Debug run confirmed `entity_components[image]` is always populated after integration setup, so the fail path is a safety net for HA API changes.

Verified the test fails when `_attr_content_type = "image/png"` is set in production code.

## Test plan

- [x] Both assertions confirmed to fail with broken production code
- [x] 288 unit + integration tests pass (pre-commit and pre-push hooks confirmed)
- [x] No production code changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)