### PR TITLE
test: delete tautological E2E scenario tests

### DIFF
--- a/tests/e2e/test_sensors_e2e.py
+++ b/tests/e2e/test_sensors_e2e.py
@@ -4,6 +4,11 @@ E2E tests for the rain_incoming integration.
 These tests run against a real HA instance in Docker with a mock RainViewer
 server. They verify the full pipeline: HTTP fetch -> tile decoding ->
 detection -> sensor state updates.
+
+Note: entity existence and basic sensor-state assertions are covered at the
+integration layer (tests/integration/test_sensors.py). The classes here
+focus on what only E2E can verify: radar image content, sensor/image
+coherence, and system log cleanliness.
 """
 from __future__ import annotations
 
@@ -11,103 +16,13 @@ import time
 from io import BytesIO
 
 import numpy as np
-import pytest
 from PIL import Image
 
 
 BINARY_SENSOR = "binary_sensor.rain_incoming_status"
 ARRIVAL_SENSOR = "sensor.rain_incoming_arrival_time"
 INTENSITY_SENSOR = "sensor.rain_incoming_intensity"
-LAST_RAIN_SENSOR = "sensor.rain_incoming_last_rain"
-IMAGE_64 = "image.rain_incoming_radar_64km"
 IMAGE_128 = "image.rain_incoming_radar_128km"
-IMAGE_256 = "image.rain_incoming_radar_256km"
-
-
-class TestIntegrationLoaded:
-    def test_binary_sensor_exists(self, ha_client):
-        state = ha_client.get_state(BINARY_SENSOR)
-        assert state is not None, f"Entity {BINARY_SENSOR} not found"
-        assert state["state"] in ("on", "off", "unavailable")
-
-    def test_arrival_sensor_exists(self, ha_client):
-        state = ha_client.get_state(ARRIVAL_SENSOR)
-        assert state is not None, f"Entity {ARRIVAL_SENSOR} not found"
-
-    def test_intensity_sensor_exists(self, ha_client):
-        state = ha_client.get_state(INTENSITY_SENSOR)
-        assert state is not None, f"Entity {INTENSITY_SENSOR} not found"
-        assert state["state"] in ("none", "light", "moderate", "heavy", "extreme", "unavailable")
-
-    def test_last_rain_sensor_exists(self, ha_client):
-        state = ha_client.get_state(LAST_RAIN_SENSOR)
-        assert state is not None, f"Entity {LAST_RAIN_SENSOR} not found"
-
-    @pytest.mark.parametrize("entity_id", [IMAGE_64, IMAGE_128, IMAGE_256])
-    def test_image_entities_exist(self, ha_client, entity_id):
-        state = ha_client.get_state(entity_id)
-        assert state is not None, f"Entity {entity_id} not found"
-
-
-class TestNoRainScenario:
-    def test_no_rain_detected(self, ha_client):
-        ha_client.set_mock_scenario("no_rain")
-        ha_client.update_entity(BINARY_SENSOR)
-        time.sleep(15)  # let the coordinator fetch tiles + run detection
-
-        state = ha_client.get_state(BINARY_SENSOR)
-        assert state is not None
-        assert state["state"] == "off", f"Expected off, got {state['state']}"
-
-    def test_arrival_time_unknown(self, ha_client):
-        state = ha_client.get_state(ARRIVAL_SENSOR)
-        assert state is not None
-        assert state["state"] in ("unknown", "unavailable", "None")
-
-
-class TestRainApproachingScenario:
-    def test_rain_approaching_detected(self, ha_client):
-        """Rain cell moving east toward the location should trigger rain_incoming."""
-        ha_client.set_mock_scenario("rain_approaching")
-        ha_client.update_entity(BINARY_SENSOR)
-        time.sleep(15)
-
-        state = ha_client.get_state(BINARY_SENSOR)
-        assert state is not None
-        assert state["state"] == "on", f"Expected on, got {state['state']}"
-
-    def test_arrival_time_in_future(self, ha_client):
-        """Approaching rain should have an arrival time set."""
-        state = ha_client.get_state(ARRIVAL_SENSOR)
-        assert state is not None
-        assert state["state"] not in ("unknown", "unavailable", "None"), \
-            f"Expected a timestamp, got {state['state']}"
-
-
-class TestRainEverywhereScenario:
-    def test_rain_detected_overhead(self, ha_client):
-        ha_client.set_mock_scenario("rain_everywhere")
-        ha_client.update_entity(BINARY_SENSOR)
-        time.sleep(5)
-
-        state = ha_client.get_state(BINARY_SENSOR)
-        assert state is not None
-        assert state["state"] == "on", f"Expected on, got {state['state']}"
-
-    def test_arrival_time_is_set(self, ha_client):
-        state = ha_client.get_state(ARRIVAL_SENSOR)
-        assert state is not None
-        assert state["state"] not in ("unknown", "unavailable", "None"), \
-            f"Expected a timestamp, got {state['state']}"
-
-    def test_intensity_shows_level_with_rain(self, ha_client):
-        """When rain is everywhere, intensity should not be 'none'."""
-        state = ha_client.get_state(INTENSITY_SENSOR)
-        assert state is not None
-        assert state["state"] != "none", \
-            f"Expected a rain intensity level, got {state['state']}"
-        assert state["state"] in ("light", "moderate", "heavy", "extreme"), \
-            f"Unexpected intensity value: {state['state']}"
 
 
 def _images_differ_significantly(


### PR DESCRIPTION
## Summary
- Delete four E2E scenario classes whose assertions are already covered at the integration layer with stronger checks: `TestIntegrationLoaded`, `TestNoRainScenario`, `TestRainApproachingScenario`, `TestRainEverywhereScenario`
- Net: 3 of 9 `time.sleep()` calls removed, -12 tests, 0 lost coverage
- Clean up dead module-level constants (`LAST_RAIN_SENSOR`, `IMAGE_64`, `IMAGE_256`) that only the deleted classes referenced

## Coverage parity
Every deleted assertion is covered at the integration layer. Key mappings:
- `test_binary_sensor_exists` → `test_binary_sensor_off_when_no_rain` + `test_binary_sensor_on_when_rain_coming`
- `test_arrival_time_unknown` → `test_arrival_sensor_unknown_when_no_rain` (stronger: asserts `== "unknown"`, not the old `in ("unknown", "unavailable", "None")`)
- `test_image_entities_exist` → `test_image_entity_created` (parametrized x3)
- Intensity / last_rain / arrival coverage preserved via integration tests

## Kept
`TestIntegratedRainValidation`, `TestValidationCanFail`, `TestSystemLogs` all have unique assertions (real sensor→image coherence, would-fail validation, log scraping) unreachable at the integration layer.

## Test plan
- [x] 294 unit + integration + contract tests pass locally
- [x] Test-expert re-review APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>