### PR TITLE
test: session-scoped manifest fixture + dedup contract tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ include = ["custom_components.*"]
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 asyncio_mode = "auto"
+asyncio_default_fixture_loop_scope = "function"
 pythonpath = ["."]
 
 [tool.coverage.run]

--- a/tests/contract/_session.py
+++ b/tests/contract/_session.py
@@ -1,0 +1,11 @@
+"""Shared aiohttp session factory for contract tests."""
+from __future__ import annotations
+
+import aiohttp
+import aiohttp.resolver
+
+
+def make_rainviewer_session() -> aiohttp.ClientSession:
+    """Create a session using the threaded resolver (avoids aiodns compat issues)."""
+    connector = aiohttp.TCPConnector(resolver=aiohttp.resolver.ThreadedResolver())
+    return aiohttp.ClientSession(connector=connector)

--- a/tests/contract/conftest.py
+++ b/tests/contract/conftest.py
@@ -1,8 +1,15 @@
 """Contract tests hit real APIs - override HA test framework fixtures."""
 from __future__ import annotations
 
+import copy
+
 import pytest
+import pytest_asyncio
 import pytest_socket
+
+from ._session import make_rainviewer_session
+
+MANIFEST_URL = "https://api.rainviewer.com/public/weather-maps.json"
 
 
 @pytest.fixture(autouse=True)
@@ -19,3 +26,27 @@ def auto_enable_custom_integrations():
 def verify_cleanup():
     """Override HA's verify_cleanup fixture - not applicable here."""
     yield
+
+
+@pytest_asyncio.fixture(scope="session", loop_scope="session")
+async def manifest() -> dict:
+    """Fetch the RainViewer manifest once per test session.
+
+    All contract tests that need manifest data share this single fetch,
+    reducing live-API calls and rate-limit exposure.
+
+    Enables real sockets here because this session fixture runs before the
+    function-scoped auto_enable_custom_integrations fixture.
+    """
+    import socket as _socket
+    pytest_socket.enable_socket()
+    if hasattr(pytest_socket, "_true_connect"):
+        _socket.socket.connect = pytest_socket._true_connect
+
+    async with make_rainviewer_session() as session:
+        async with session.get(MANIFEST_URL) as resp:
+            assert resp.status == 200, (
+                f"Manifest fetch failed: HTTP {resp.status} from {MANIFEST_URL}"
+            )
+            data = await resp.json(content_type=None)
+            return copy.deepcopy(data)

--- a/tests/contract/test_rainviewer_contract.py
+++ b/tests/contract/test_rainviewer_contract.py
@@ -12,13 +12,12 @@ from __future__ import annotations
 
 from io import BytesIO
 
-import aiohttp
-import aiohttp.resolver
 import numpy as np
 import pytest
 from PIL import Image
 
-MANIFEST_URL = "https://api.rainviewer.com/public/weather-maps.json"
+from ._session import make_rainviewer_session
+
 TILE_BASE_URL = "https://tilecache.rainviewer.com"
 ZOOM = 7
 TILE_X, TILE_Y = 117, 76  # Terry Hills
@@ -26,28 +25,14 @@ COLOUR_SCHEME = 6
 TILE_SIZE = 256
 
 
-def _session() -> aiohttp.ClientSession:
-    """Create a session using the threaded resolver (avoids aiodns compat issues)."""
-    connector = aiohttp.TCPConnector(resolver=aiohttp.resolver.ThreadedResolver())
-    return aiohttp.ClientSession(connector=connector)
+@pytest.mark.asyncio
+async def test_manifest_returns_valid_json(manifest):
+    assert isinstance(manifest, dict)
 
 
 @pytest.mark.asyncio
-async def test_manifest_returns_valid_json():
-    async with _session() as session:
-        async with session.get(MANIFEST_URL) as resp:
-            assert resp.status == 200
-            data = await resp.json(content_type=None)
-            assert isinstance(data, dict)
-
-
-@pytest.mark.asyncio
-async def test_manifest_has_radar_past_frames():
-    async with _session() as session:
-        async with session.get(MANIFEST_URL) as resp:
-            data = await resp.json(content_type=None)
-
-    radar = data.get("radar")
+async def test_manifest_has_radar_past_frames(manifest):
+    radar = manifest.get("radar")
     assert radar is not None, "Missing 'radar' key in manifest"
 
     past = radar.get("past")
@@ -56,12 +41,8 @@ async def test_manifest_has_radar_past_frames():
 
 
 @pytest.mark.asyncio
-async def test_frame_has_required_fields():
-    async with _session() as session:
-        async with session.get(MANIFEST_URL) as resp:
-            data = await resp.json(content_type=None)
-
-    frame = data["radar"]["past"][-1]
+async def test_frame_has_required_fields(manifest):
+    frame = manifest["radar"]["past"][-1]
     assert "time" in frame, f"Frame missing 'time': {frame}"
     assert "path" in frame, f"Frame missing 'path': {frame}"
     assert isinstance(frame["time"], int)
@@ -69,13 +50,11 @@ async def test_frame_has_required_fields():
 
 
 @pytest.mark.asyncio
-async def test_tile_returns_valid_png():
-    async with _session() as session:
-        async with session.get(MANIFEST_URL) as resp:
-            data = await resp.json(content_type=None)
-        path = data["radar"]["past"][-1]["path"]
+async def test_tile_returns_valid_png(manifest):
+    path = manifest["radar"]["past"][-1]["path"]
+    tile_url = f"{TILE_BASE_URL}{path}/{TILE_SIZE}/{ZOOM}/{TILE_X}/{TILE_Y}/{COLOUR_SCHEME}/0.png"
 
-        tile_url = f"{TILE_BASE_URL}{path}/{TILE_SIZE}/{ZOOM}/{TILE_X}/{TILE_Y}/{COLOUR_SCHEME}/0.png"
+    async with make_rainviewer_session() as session:
         async with session.get(tile_url) as resp:
             assert resp.status == 200
             tile_bytes = await resp.read()
@@ -85,28 +64,14 @@ async def test_tile_returns_valid_png():
 
 
 @pytest.mark.asyncio
-async def test_tile_is_rgba_decodable():
-    async with _session() as session:
-        async with session.get(MANIFEST_URL) as resp:
-            data = await resp.json(content_type=None)
-        path = data["radar"]["past"][-1]["path"]
+async def test_tile_is_rgba_decodable(manifest):
+    path = manifest["radar"]["past"][-1]["path"]
+    tile_url = f"{TILE_BASE_URL}{path}/{TILE_SIZE}/{ZOOM}/{TILE_X}/{TILE_Y}/{COLOUR_SCHEME}/0.png"
 
-        tile_url = f"{TILE_BASE_URL}{path}/{TILE_SIZE}/{ZOOM}/{TILE_X}/{TILE_Y}/{COLOUR_SCHEME}/0.png"
+    async with make_rainviewer_session() as session:
         async with session.get(tile_url) as resp:
             tile_bytes = await resp.read()
 
     img = Image.open(BytesIO(tile_bytes)).convert("RGBA")
     arr = np.array(img, dtype=np.uint8)
     assert arr.shape == (TILE_SIZE, TILE_SIZE, 4)
-
-
-@pytest.mark.asyncio
-async def test_zoom_7_is_supported():
-    async with _session() as session:
-        async with session.get(MANIFEST_URL) as resp:
-            data = await resp.json(content_type=None)
-        path = data["radar"]["past"][-1]["path"]
-
-        url = f"{TILE_BASE_URL}{path}/{TILE_SIZE}/{ZOOM}/{TILE_X}/{TILE_Y}/{COLOUR_SCHEME}/0.png"
-        async with session.get(url) as resp:
-            assert resp.status == 200


### PR DESCRIPTION
## Summary
- Add session-scoped `manifest` fixture in `tests/contract/conftest.py` - one live fetch shared by all tests instead of six
- Extract `make_rainviewer_session` into `tests/contract/_session.py` as single source of truth (was duplicated as `_session()` / `_make_session()`)
- Delete `test_zoom_7_is_supported` - strict subset of `test_tile_returns_valid_png`
- Manifest fixture returns `copy.deepcopy(data)` to prevent latent shared-mutable-state leaks
- Add `asyncio_default_fixture_loop_scope = "function"` to silence pytest-asyncio 0.24 deprecation warning

## Live API call reduction
- Before: 6 manifest + 3 tile = 9 HTTP calls per run
- After: 1 manifest + 2 tile = 3 HTTP calls per run

## Test plan
- [x] 5 contract tests pass locally (2.71s)
- [x] 288 unit + integration tests pass
- [x] Test-expert re-review APPROVED

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>