### PR TITLE
fix: remove 'None' string from sensor state guards (+ TDD unit tests)

### DIFF
--- a/custom_components/rain_incoming/sensor.py
+++ b/custom_components/rain_incoming/sensor.py
@@ -176,7 +176,7 @@ class LastRainNearbySensor(
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()
         last_state = await self.async_get_last_state()
-        if last_state and last_state.state not in ("unknown", "unavailable", "None"):
+        if last_state and last_state.state not in ("unknown", "unavailable"):
             from datetime import datetime
             try:
                 self.coordinator.last_rain_nearby_time = datetime.fromisoformat(

--- a/tests/integration/test_sensors.py
+++ b/tests/integration/test_sensors.py
@@ -104,7 +104,7 @@ async def test_arrival_sensor_unknown_when_no_rain(hass: HomeAssistant, mock_ent
     await _setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
     state = hass.states.get("sensor.rain_incoming_arrival_time")
     assert state is not None
-    assert state.state in ("unknown", "None")
+    assert state.state == "unknown"
 
 
 @pytest.mark.asyncio
@@ -378,4 +378,4 @@ async def test_last_rain_sensor_exists(hass: HomeAssistant, mock_entry):
 async def test_last_rain_sensor_unknown_when_no_rain_history(hass: HomeAssistant, mock_entry):
     await _setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
     state = hass.states.get("sensor.rain_incoming_last_rain")
-    assert state.state in ("unknown", "None")
+    assert state.state == "unknown"

--- a/tests/integration/test_sensors.py
+++ b/tests/integration/test_sensors.py
@@ -97,6 +97,8 @@ async def test_arrival_sensor_has_timestamp_when_rain_coming(hass: HomeAssistant
     assert state is not None
     assert state.state != "unknown"
     assert state.state != "unavailable"
+    from datetime import datetime
+    datetime.fromisoformat(state.state)  # must be a parseable ISO 8601 timestamp
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_sensor_restore.py
+++ b/tests/unit/test_sensor_restore.py
@@ -1,0 +1,198 @@
+"""Unit tests for LastRainNearbySensor state restore path.
+
+TDD: these tests are written to verify the restore guard is robust to legacy
+state values. In particular, old versions persisted the literal string "None"
+as a sensor state. The guard must not silently skip these - it should attempt
+datetime.fromisoformat("None"), catch the ValueError, log a WARNING, and leave
+coordinator.last_rain_nearby_time unchanged.
+"""
+from __future__ import annotations
+
+import logging
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.rain_incoming.sensor import LastRainNearbySensor
+
+
+def _make_coordinator():
+    coordinator = MagicMock()
+    coordinator.last_rain_nearby_time = None
+    return coordinator
+
+
+def _make_entry():
+    entry = MagicMock()
+    entry.entry_id = "test_entry_123"
+    entry.data = {}
+    return entry
+
+
+def _make_sensor(coordinator, entry):
+    """Build a LastRainNearbySensor with minimal mocks, bypassing CoordinatorEntity init."""
+    sensor = LastRainNearbySensor.__new__(LastRainNearbySensor)
+    sensor.coordinator = coordinator
+    sensor._entry = entry
+    sensor._attr_unique_id = f"{entry.entry_id}_last_rain_nearby"
+    return sensor
+
+
+class TestLastRainNearbyRestore:
+    """Restore path for LastRainNearbySensor."""
+
+    @pytest.mark.asyncio
+    async def test_legacy_none_string_logs_warning_and_leaves_time_unchanged(self, caplog):
+        """Restoring state "None" (legacy string) must log a WARNING and not update coordinator."""
+        coordinator = _make_coordinator()
+        entry = _make_entry()
+        sensor = _make_sensor(coordinator, entry)
+
+        last_state = MagicMock()
+        last_state.state = "None"
+
+        with (
+            patch.object(
+                LastRainNearbySensor,
+                "async_get_last_state",
+                new=AsyncMock(return_value=last_state),
+            ),
+        ):
+            with patch(
+                "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ), patch(
+                "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ):
+                with caplog.at_level(logging.WARNING, logger="custom_components.rain_incoming.sensor"):
+                    await LastRainNearbySensor.async_added_to_hass(sensor)
+
+        # The guard must NOT suppress the parse - it should hit ValueError and warn
+        assert coordinator.last_rain_nearby_time is None, (
+            "coordinator.last_rain_nearby_time should remain None when "
+            'restoring the legacy "None" string'
+        )
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert any("None" in msg for msg in warning_messages), (
+            f'Expected a WARNING mentioning "None" but got: {warning_messages}'
+        )
+
+    @pytest.mark.asyncio
+    async def test_valid_iso_timestamp_restores_coordinator_time(self):
+        """Restoring a valid ISO 8601 timestamp updates coordinator.last_rain_nearby_time."""
+        from datetime import datetime, timezone
+
+        coordinator = _make_coordinator()
+        entry = _make_entry()
+        sensor = _make_sensor(coordinator, entry)
+
+        iso_ts = "2026-04-07T10:30:00+00:00"
+        last_state = MagicMock()
+        last_state.state = iso_ts
+
+        with (
+            patch.object(
+                LastRainNearbySensor,
+                "async_get_last_state",
+                new=AsyncMock(return_value=last_state),
+            ),
+        ):
+            with patch(
+                "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ), patch(
+                "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ):
+                await LastRainNearbySensor.async_added_to_hass(sensor)
+
+        expected = datetime.fromisoformat(iso_ts)
+        assert coordinator.last_rain_nearby_time == expected
+
+    @pytest.mark.asyncio
+    async def test_unknown_state_skips_restore(self, caplog):
+        """State 'unknown' must not trigger any datetime parse attempt."""
+        coordinator = _make_coordinator()
+        entry = _make_entry()
+        sensor = _make_sensor(coordinator, entry)
+
+        last_state = MagicMock()
+        last_state.state = "unknown"
+
+        with (
+            patch.object(
+                LastRainNearbySensor,
+                "async_get_last_state",
+                new=AsyncMock(return_value=last_state),
+            ),
+        ):
+            with patch(
+                "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ), patch(
+                "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ):
+                with caplog.at_level(logging.WARNING, logger="custom_components.rain_incoming.sensor"):
+                    await LastRainNearbySensor.async_added_to_hass(sensor)
+
+        assert coordinator.last_rain_nearby_time is None
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert warning_messages == [], f"Expected no warnings, got: {warning_messages}"
+
+    @pytest.mark.asyncio
+    async def test_unavailable_state_skips_restore(self, caplog):
+        """State 'unavailable' must not trigger any datetime parse attempt."""
+        coordinator = _make_coordinator()
+        entry = _make_entry()
+        sensor = _make_sensor(coordinator, entry)
+
+        last_state = MagicMock()
+        last_state.state = "unavailable"
+
+        with (
+            patch.object(
+                LastRainNearbySensor,
+                "async_get_last_state",
+                new=AsyncMock(return_value=last_state),
+            ),
+        ):
+            with patch(
+                "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ), patch(
+                "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ):
+                with caplog.at_level(logging.WARNING, logger="custom_components.rain_incoming.sensor"):
+                    await LastRainNearbySensor.async_added_to_hass(sensor)
+
+        assert coordinator.last_rain_nearby_time is None
+        warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+        assert warning_messages == [], f"Expected no warnings, got: {warning_messages}"
+
+    @pytest.mark.asyncio
+    async def test_no_last_state_skips_restore(self):
+        """No persisted state (first boot) must leave coordinator.last_rain_nearby_time as None."""
+        coordinator = _make_coordinator()
+        entry = _make_entry()
+        sensor = _make_sensor(coordinator, entry)
+
+        with (
+            patch.object(
+                LastRainNearbySensor,
+                "async_get_last_state",
+                new=AsyncMock(return_value=None),
+            ),
+        ):
+            with patch(
+                "homeassistant.helpers.restore_state.RestoreEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ), patch(
+                "homeassistant.helpers.update_coordinator.CoordinatorEntity.async_added_to_hass",
+                new=AsyncMock(),
+            ):
+                await LastRainNearbySensor.async_added_to_hass(sensor)
+
+        assert coordinator.last_rain_nearby_time is None


### PR DESCRIPTION
## Summary
- Remove `"None"` from `LastRainNearbySensor.async_added_to_hass` restore-state exclusion tuple - the literal string never occurs in practice (HA renders Python `None` as `"unknown"` for TIMESTAMP device class)
- Tighten two integration tests from `in ("unknown", "None")` to `== "unknown"`
- Add 5 unit tests in `tests/unit/test_sensor_restore.py` covering the restore path end-to-end - this is the missing TDD trail that the previous review flagged
- Tighten `test_arrival_sensor_has_timestamp_when_rain_coming` to parse the state as ISO 8601 (was `!= "unknown"`, now proves it's a real timestamp)

## TDD trail
- `test_legacy_none_string_logs_warning_and_leaves_time_unchanged` - red against the old code (old guard silently skipped `"None"`, no warning logged), green against the new code (falls through to `fromisoformat("None")`, caught by existing `except ValueError` block, logs warning)
- `test_unknown_state_skips_restore` / `test_unavailable_state_skips_restore` - assert no warning is logged, proving the early-return guard actually fires rather than relying on the exception catch

## Backward compat note
If any user upgraded from a hypothetical old version that persisted `"None"` as restore state, the removed guard entry means `datetime.fromisoformat("None")` is now called instead of silently skipped. The existing `except (ValueError, TypeError)` block catches this and logs a WARNING - no crash, no data corruption, sensor just starts fresh. Safe failure mode.

## Test plan
- [x] 293 unit + integration tests pass locally
- [x] Test-expert review APPROVED (third pass)
- [x] Inverse validation: confirmed the no-warning assertions fail when the guard is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>