### PR TITLE
chore: harden pre-push hook to catch E2E/contract collection failures

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,11 +1,27 @@
 #!/bin/bash
-echo "Running unit + integration tests before push..."
+set -e
 cd "$(git rev-parse --show-toplevel)"
-.venv/bin/pytest tests/unit/ tests/integration/ -q --tb=line 2>&1
-exit_code=$?
-if [ $exit_code -ne 0 ]; then
+
+echo "Compiling all test files (catches syntax errors in layers we don't run)..."
+.venv/bin/python -m compileall -q tests/ || {
+    echo ""
+    echo "PUSH BLOCKED: test files failed to compile. Fix syntax errors before pushing."
+    exit 1
+}
+
+echo "Collecting E2E and contract tests (catches import/reference errors)..."
+.venv/bin/pytest --collect-only -q tests/e2e tests/contract > /dev/null || {
+    echo ""
+    echo "PUSH BLOCKED: E2E or contract test collection failed. Fix imports/references before pushing."
+    .venv/bin/pytest --collect-only tests/e2e tests/contract 2>&1 | tail -20
+    exit 1
+}
+
+echo "Running unit + integration tests..."
+.venv/bin/pytest tests/unit/ tests/integration/ -q --tb=line || {
     echo ""
     echo "PUSH BLOCKED: tests failed. Fix them before pushing."
     exit 1
-fi
-echo "Tests passed. Pushing."
+}
+
+echo "All checks passed. Pushing."


### PR DESCRIPTION
## Summary
The previous hook ran unit + integration tests only. It missed:
- Syntax errors in E2E/contract test files (modules we don't execute)
- Import/reference errors that only surface at collection time
- Leftover stubs from incomplete deletions (e.g. `def ` without a name)

This gap was caught when a dev agent pushed a `def ` stub in `tests/e2e/conftest.py`. The main suite was green and the hook passed.

## New gates
1. `compileall tests/` - catches raw syntax errors in every test file
2. `pytest --collect-only tests/e2e tests/contract` - catches import/reference errors in layers the main push doesn't run
3. `pytest unit + integration` - unchanged

Still no Docker required, still fast (~12s total on a clean tree).

## Test plan
- [x] Hook passes on clean main
- [x] Hook blocks on the `def ` stub (verified by temporarily restoring the broken conftest.py)
- [x] Hook ran against its own commit during push

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>