### PR TITLE
feat: expose last_update_success on binary_sensor + add E2E helper

### DIFF
--- a/custom_components/rain_incoming/binary_sensor.py
+++ b/custom_components/rain_incoming/binary_sensor.py
@@ -72,4 +72,6 @@ class RainIncomingBinarySensor(CoordinatorEntity[RainDetectorCoordinator], Binar
         if self.coordinator.data is not None:
             attrs["confidence"] = self.coordinator.data.confidence.value
             attrs["frame_count"] = self.coordinator.data.frame_count
+        if self.coordinator.last_update_success_time is not None:
+            attrs["last_update_success"] = self.coordinator.last_update_success_time.isoformat()
         return attrs

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -119,6 +119,42 @@ class HAClient:
                 time.sleep(delay)
         return None
 
+    def wait_for_coordinator_cycle(
+        self,
+        entity_id: str,
+        timeout: float = 60.0,
+        interval: float = 2.0,
+    ) -> dict:
+        """Trigger an entity update and wait for the coordinator to run a fresh cycle.
+
+        Handles HA's update_entity debounce by repeatedly nudging the entity and
+        polling the last_update_success attribute until it advances past the
+        pre-trigger value. Returns the new state dict once the cycle completes.
+        """
+        start = time.time()
+        deadline = start + timeout
+
+        pre_state = self.get_state(entity_id)
+        pre = pre_state.get("attributes", {}).get("last_update_success") if pre_state else None
+
+        while time.time() < deadline:
+            self.update_entity(entity_id)
+            time.sleep(interval)
+            state = self.get_state(entity_id)
+            if state is not None:
+                current = state.get("attributes", {}).get("last_update_success")
+                if current is not None and current != pre:
+                    return state
+
+        elapsed = time.time() - start
+        last_state = self.get_state(entity_id)
+        last_value = last_state.get("attributes", {}).get("last_update_success") if last_state else None
+        raise TimeoutError(
+            f"wait_for_coordinator_cycle: entity {entity_id!r} did not advance "
+            f"last_update_success past {pre!r} within {timeout}s (elapsed {elapsed:.1f}s). "
+            f"Last seen value: {last_value!r}."
+        )
+
     def poll_entity_state(
         self,
         entity_id: str,

--- a/tests/integration/test_sensors.py
+++ b/tests/integration/test_sensors.py
@@ -242,6 +242,25 @@ async def test_config_values_not_in_attributes(hass: HomeAssistant, mock_entry, 
 
 
 @pytest.mark.asyncio
+async def test_binary_sensor_exposes_last_update_success_attribute(hass: HomeAssistant, mock_entry):
+    await _setup_integration(hass, mock_entry, MOCK_RESULT_RAIN_COMING)
+
+    # In production, last_update_success_time is set inside _async_update_data, but the
+    # integration test patches that method out. Seed it manually and push new data through
+    # the coordinator so all CoordinatorEntity listeners write a fresh state snapshot.
+    coordinator = hass.data[DOMAIN][mock_entry.entry_id]
+    coordinator.last_update_success_time = datetime(2026, 4, 11, 0, 0, 0, tzinfo=timezone.utc)
+    coordinator.async_set_updated_data(MOCK_RESULT_RAIN_COMING)
+    await hass.async_block_till_done()
+
+    state = hass.states.get("binary_sensor.rain_incoming_status")
+    assert state is not None
+    assert "last_update_success" in state.attributes
+    value = state.attributes["last_update_success"]
+    datetime.fromisoformat(value)  # raises ValueError if not a valid ISO 8601 string
+
+
+@pytest.mark.asyncio
 async def test_binary_sensor_still_has_dynamic_attributes(hass: HomeAssistant, mock_entry):
     await _setup_integration(hass, mock_entry, MOCK_RESULT_RAIN_COMING)
     state = hass.states.get("binary_sensor.rain_incoming_status")


### PR DESCRIPTION
## Summary
Testability improvement landing the foundation for fixing a flaky E2E test. No test fix in this PR — the follow-up will use these additions.

### Production change
- New binary_sensor attribute `last_update_success` exposing `coordinator.last_update_success_time` as an ISO string. Name mirrors HA's existing `DataUpdateCoordinator.last_update_success` boolean so any HA dev reading the attribute knows what it means.
- Only included when the coordinator has had at least one successful cycle — absent otherwise.

### E2E helper
- New `HAClient.wait_for_coordinator_cycle(entity_id, timeout=60, interval=2)` in `tests/e2e/conftest.py`.
- Captures the pre-trigger `last_update_success` timestamp, then loops `update_entity` → short wait → re-check until the timestamp advances. Naturally outlasts HA's `update_entity` debounce window (which was causing the flaky test).
- Not used yet — follow-up PR will apply it to the failing `TestValidationCanFail::test_different_scenarios_produce_different_images` and the 2 latent-risk siblings.

## Why
PR #22's E2E failure was root-caused to HA debouncing `update_entity` calls made shortly after a recent successful refresh. Polling `binary_sensor.last_updated` was unreliable because the coordinator returned cached data instead of running a new cycle. `last_update_success` is a definitive signal that a *real* coordinator cycle completed.

## TDD
- New integration test `test_binary_sensor_exposes_last_update_success_attribute` added alongside existing attribute tests.
- Confirmed RED: first run against unmodified `binary_sensor.py` failed with `AssertionError: assert 'last_update_success' in {...existing attrs...}`.
- Added the 2-line production change. Confirmed GREEN.
- Existing attribute tests (`test_binary_sensor_still_has_dynamic_attributes`, `test_config_values_not_in_attributes`) untouched and still pass.

## Test plan
- [x] 294 unit + integration tests pass locally
- [x] Hardened pre-push hook (PR #21) passes all 3 gates
- [x] Test-expert approved (naming polish applied: `last_coordinator_update` → `last_update_success`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>