### PR TITLE
test: add parser-to-render roundtrip test for palette integrity

### DIFF
--- a/tests/unit/radar/test_composite_radar_only.py
+++ b/tests/unit/radar/test_composite_radar_only.py
@@ -185,6 +185,83 @@ class TestComposableRenderingPipeline:
                 f"should survive filter, got alpha={result[1, i, 3]}"
             )
 
+    def test_palette_roundtrip_parser_filter_render(self):
+        """Parser-to-render roundtrip guard against palette drift.
+
+        Uses HARDCODED production palette values rather than reading from
+        PRECIP_COLOURS at runtime, so a silent palette change can't regenerate
+        a matching synthetic tile. The sanity check catches the "palette changed,
+        test not updated" case with a descriptive message.
+        """
+        from custom_components.rain_incoming.providers.rainviewer import (
+            PRECIP_COLOURS,
+            TILE_SIZE,
+            _tile_to_intensity_array,
+        )
+        from custom_components.rain_incoming.radar.composite import (
+            filter_precipitation_pixels,
+            render_gif,
+        )
+        from tests.e2e.image_helpers import gif_has_precipitation_pixels
+
+        # PRECIP_COLOURS[3] - moderate rain. Must be updated in both files together.
+        _TILE_R, _TILE_G, _TILE_B = 81, 197, 232
+        _EXPECTED_INTENSITY = 0.38
+
+        tile_img = Image.new("RGBA", (TILE_SIZE, TILE_SIZE), (_TILE_R, _TILE_G, _TILE_B, 255))
+        buf = BytesIO()
+        tile_img.save(buf, format="PNG")
+        tile_bytes = buf.getvalue()
+
+        matching = [
+            (r, g, b, intensity)
+            for r, g, b, intensity in PRECIP_COLOURS
+            if abs(r - _TILE_R) < 2 and abs(g - _TILE_G) < 2 and abs(b - _TILE_B) < 2
+        ]
+        assert matching, (
+            f"Production PRECIP_COLOURS no longer contains the hardcoded tile colour "
+            f"({_TILE_R},{_TILE_G},{_TILE_B}) - palette has diverged. "
+            f"Update the hardcoded constants in this test AND in PRECIP_COLOURS "
+            f"to keep them in sync."
+        )
+
+        intensity_array = _tile_to_intensity_array(tile_bytes)
+
+        assert intensity_array.shape == (TILE_SIZE, TILE_SIZE), (
+            f"Expected intensity array shape ({TILE_SIZE}, {TILE_SIZE}), "
+            f"got {intensity_array.shape}"
+        )
+        assert np.allclose(intensity_array, _EXPECTED_INTENSITY, atol=0.01), (
+            f"Parser should produce intensity ~{_EXPECTED_INTENSITY} for "
+            f"the hardcoded production colour ({_TILE_R},{_TILE_G},{_TILE_B}), "
+            f"got mean={intensity_array.mean():.4f}. "
+            f"Check PRECIP_COLOURS in rainviewer.py still contains this entry."
+        )
+
+        rgba_array = np.array(Image.open(BytesIO(tile_bytes)), dtype=np.uint8)
+        filtered = filter_precipitation_pixels(rgba_array)
+
+        assert (filtered[:, :, 3] > 0).all(), (
+            f"filter_precipitation_pixels should preserve every pixel since the "
+            f"tile is filled with production colour ({_TILE_R},{_TILE_G},{_TILE_B}). "
+            f"Check _PRECIP_RGB in composite.py is derived from PRECIP_COLOURS."
+        )
+
+        filtered_img = Image.fromarray(filtered, mode="RGBA")
+        gif_bytes = render_gif([filtered_img])
+
+        has_precip, fraction = gif_has_precipitation_pixels(gif_bytes)
+        assert has_precip, (
+            f"Rendered GIF from production colour ({_TILE_R},{_TILE_G},{_TILE_B}) "
+            f"should be detected as precipitation by gif_has_precipitation_pixels, "
+            f"got has_precip={has_precip}, fraction={fraction:.4f}"
+        )
+        assert fraction > 0.9, (
+            f"GIF filled entirely with a production palette colour should have "
+            f"~100% precipitation pixels (>0.9 after GIF quantisation fringe), "
+            f"got fraction={fraction:.4f}"
+        )
+
     @pytest.mark.asyncio
     async def test_dry_radar_over_black_has_zero_precipitation_pixels(self):
         """Dry radar (transparent tiles) composited over black must have


### PR DESCRIPTION
## Summary
Task #107 from the palette safety net follow-ups. Adds a defense-in-depth regression test that connects parser → filter → render_gif end-to-end with a hardcoded production palette colour. Would catch palette drift from either side of the semantic bridge.

## What the test does
1. **Sanity check**: asserts the hardcoded RGB `(81, 197, 232)` is still in `PRECIP_COLOURS` (runs first so a palette divergence shows a clear "update both sides" message before any cryptic downstream failure).
2. **Build** a 256x256 RGBA PNG filled with the hardcoded colour.
3. **Parse** through `_tile_to_intensity_array`, assert intensity == `0.38` (the expected value for that palette entry) with `atol=0.01`.
4. **Filter** the RGBA array through `filter_precipitation_pixels`, assert every pixel survives.
5. **Render** via production `render_gif`.
6. **Detect** via `gif_has_precipitation_pixels`, assert `has_precip=True` and `fraction > 0.9` (solid tile should be ~100% precipitation pixels after GIF quantisation).

## Why hardcoded values

Reading `PRECIP_COLOURS[3]` at runtime would let palette drift silently regenerate a matching synthetic tile and still pass. Hardcoding means palette drift breaks the test immediately. This is NOT the "tests re-encode production constants" anti-pattern (#109) — a regression test that pins a known-good value is the CORRECT response to the original bug at `b4a0bf4`. The sanity check mitigates the "legitimate palette change, forgot to update test" failure mode by firing first with a descriptive error pointing at both files.

## Coverage boundaries
This test covers parser → filter → render_gif. It deliberately skips `composite_frames`, `alpha_composite` over a map background, range rings, crosshair, BILINEAR resize, and confidence map application — those stages don't affect whether precipitation pixels survive palette matching, only add non-precipitation overlay pixels. Individual unit tests at those boundaries already exist (PR #24). This test is defense in depth for the semantic bridge, not a substitute.

## TDD inverse validation
- **Break 1 (parser)**: replaced `PRECIP_COLOURS[3]` with `(50, 50, 50, 0.5)`. Closest remaining palette entry to `(81, 197, 232)` is `(0, 154, 213)` at L2=93.7, above `MAX_COLOUR_DISTANCE=60.0`. Parser returns 0.0 for every pixel. Test FAILED on the intensity assertion. Reverted.
- **Break 2 (renderer)**: replaced `_PRECIP_RGB` with `[[99, 99, 99]]`. Filter zeroed all alpha. Test FAILED on the filter assertion. Reverted.
- **Sanity check verification**: temporarily set `_TILE_R = 99` (not a palette entry). Test FAILED on the sanity check BEFORE the parser was called, with the intended descriptive message. Reverted.

## Test-expert review notes
Approved after two polish rounds:
1. Moved the sanity check before the parser assertion so palette drift surfaces the clear message first.
2. Tightened `fraction > 0.5` to `> 0.9` — the original was loose enough that 49% of pixels could be broken and the test would still pass. Solid-colour tile through GIF quantisation should land at ~1.0.
3. Docstring rewritten to say "parser-to-render" not "full-pipeline" since the test doesn't exercise compositing stages.

## Out-of-scope observation (follow-up)
`_colour_to_intensity` in `rainviewer.py` (lines 57-70) is an unused scalar Python-loop version of `_tile_to_intensity_array`'s vectorised logic. Only exercised by its own unit tests. Candidate for dead-code removal in a separate PR.

## Test plan
- [x] 298 unit + integration tests pass locally
- [x] Hardened pre-push hook all 3 gates green
- [x] Test-expert approved after polish
- [x] Inverse validation confirmed against both parser and renderer divergence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>