### PR TITLE
fix: targeted E2E volume cleanup to prevent clobbering dev HA volume

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,9 @@
+# This compose file is shared between `make dev` (ha-dev-config volume) and
+# the E2E test fixture (ha-e2e-config volume). The two contexts pick their
+# volume via the HA_VOLUME env var. NEVER run `docker compose down -v`
+# against this file - it removes ALL volumes declared below, including the
+# dev volume that isn't in use by the current context.
+
 services:
   homeassistant:
     container_name: ${HA_CONTAINER:-ha-dev}

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -61,6 +61,11 @@ _DOCKER_ENV = {
     "HA_PORT": str(E2E_HA_PORT),
 }
 
+# docker compose prefixes named volumes with the project name (derived from the repo
+# directory, "incoming_rain"). We need the full name for `docker volume rm` since that
+# command is not compose-aware and won't apply the prefix automatically.
+_E2E_DOCKER_VOLUME = f"incoming_rain_{_DOCKER_ENV['HA_VOLUME']}"
+
 
 class HAClient:
     """Simple REST client for the HA instance."""
@@ -231,10 +236,20 @@ def ha_container(mock_server):
         "RAINVIEWER_TILE_URL": f"http://host.docker.internal:{MOCK_PORT}",
     }
 
-    # Always start fresh - remove old E2E container and volume for a clean slate
+    # Always start fresh - remove old E2E container and volume for a clean slate.
+    # We deliberately do NOT use `down -v` here: that flag is project-scoped and
+    # would remove every named volume declared in docker-compose.dev.yml - including
+    # ha-dev-config, which belongs to the developer's manual dev instance.
+    # Instead, stop the container without touching volumes, then remove just the
+    # E2E volume by its full docker name (compose prefixes named volumes with the
+    # project name, so the raw HA_VOLUME value won't match what docker sees).
     subprocess.run(
-        ["docker", "compose", "-f", "docker-compose.dev.yml", "down", "-v"],
+        ["docker", "compose", "-f", "docker-compose.dev.yml", "down"],
         capture_output=True, env=env,
+    )
+    subprocess.run(
+        ["docker", "volume", "rm", "-f", _E2E_DOCKER_VOLUME],
+        capture_output=True,
     )
     # Remove stale token
     try:


### PR DESCRIPTION
## Summary
Fixes a data-loss bug where the E2E test fixture was wiping the developer's local HA dev instance volume as a side effect of its cleanup step.

## Root cause
`tests/e2e/conftest.py` was running:
\`\`\`python
subprocess.run(["docker", "compose", "-f", "docker-compose.dev.yml", "down", "-v"], ...)
\`\`\`

\`docker-compose.dev.yml\` declares BOTH named volumes at the top level:
\`\`\`yaml
volumes:
  ha-dev-config:     # developer's manual dev instance
  ha-e2e-config:     # E2E test throwaway
\`\`\`

The \`-v\` flag on \`docker compose down\` is **project-scoped**, not service-scoped — it removes every named volume declared in the compose file under the current project name. The E2E fixture sets \`HA_VOLUME=ha-e2e-config\` as an env var to scope the service's mount, but \`-v\` ignores the service-level mount and walks the top-level \`volumes:\` section. Both dev and E2E contexts default to the same compose project name (directory = \`incoming_rain\`), so \`down -v\` from E2E removed both volumes.

The fixture comment at line 57 claimed "isolated container, volume, and port to avoid clobbering dev state" — container and port ARE isolated, volume was NOT.

User's dev instance had been blown away at least twice because of this.

## Fix
- Replace \`down -v\` with \`down\` (container + network only, no volumes).
- Follow with explicit \`docker volume rm -f incoming_rain_ha-e2e-config\` targeting ONLY the E2E volume by its full docker-visible name (note the \`incoming_rain_\` prefix that compose adds automatically).
- New module-level constant \`_E2E_DOCKER_VOLUME\` with a comment explaining the prefix requirement.
- Load-bearing comment block in the fixture explaining why \`-v\` is unsafe here.
- Header comment in \`docker-compose.dev.yml\` documenting the volume isolation contract.

## Verification
- Static-only. The fix was NOT verified by running the E2E fixture end-to-end, because doing so against the currently-live dev volume would risk reproducing the bug if the fix were wrong.
- Dev volume \`incoming_rain_ha-dev-config\` confirmed still present after the fix was written (\`docker volume ls\`).
- 298 unit + integration tests pass, all 3 gates of the hardened pre-push hook green.

## Follow-ups tracked (not in this PR)
- Set \`COMPOSE_PROJECT_NAME=incoming_rain_e2e\` in \`_DOCKER_ENV\` to get proper docker-compose project-namespace isolation. Eliminates the hardcoded \`incoming_rain_\` prefix fragility. Test-expert's recommended next step.
- Add a pre-push hook grep check for \`docker compose down -v\` against compose files, to prevent this regression class.

## Test-expert review
APPROVED with follow-up. Direct quote: "Ship this commit. The data-loss bug is fixed, no new bugs introduced, comments are honest about the constraint. The follow-up to file is: implement Option B (set COMPOSE_PROJECT_NAME) in a separate branch to close the prefix fragility permanently."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>