### PR TITLE
feat: add map_styles module (Voyager, OSM, OSM Dark, ESRI Imagery)

### DIFF
--- a/custom_components/rain_incoming/radar/map_styles.py
+++ b/custom_components/rain_incoming/radar/map_styles.py
@@ -1,0 +1,200 @@
+"""Selectable base map styles for the radar composite.
+
+Each style encapsulates the tile fetching + any post-processing needed to
+produce a finished 256x256 RGBA base map tile for a given (zoom, x, y). The
+renderer delegates tile fetching to the style's `fetch_tile` function so new
+styles can be added without changing the compositing pipeline.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from io import BytesIO
+from typing import Awaitable, Callable
+
+import aiohttp
+import numpy as np
+from PIL import Image, ImageEnhance
+
+_LOGGER = logging.getLogger(__name__)
+
+# Saturation multiplier applied to OSM tiles before the HSV V-invert + feature lift.
+# Lower values give a more muted "dark mode" aesthetic closer to the original
+# HSV V-invert experiment the user approved. Tune here if you want the OSM
+# dark variant more/less saturated.
+_OSM_DARK_SATURATION_FACTOR = 0.75
+
+_TILE_SIZE = 256
+
+_USER_AGENT = "home-assistant rain_incoming"
+
+
+class MapStyle(StrEnum):
+    VOYAGER = "voyager"
+    OSM_STANDARD = "osm_standard"
+    OSM_DARK = "osm_dark"
+    ESRI_IMAGERY = "esri_imagery"
+
+
+FetchTileFn = Callable[[aiohttp.ClientSession, int, int, int], Awaitable[Image.Image | None]]
+
+
+@dataclass(frozen=True)
+class MapStyleDefinition:
+    style: MapStyle
+    display_name: str
+    attribution: str
+    fetch_tile: FetchTileFn
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+async def _fetch_png(session: aiohttp.ClientSession, url: str) -> Image.Image | None:
+    """Fetch a PNG tile URL and return it as an RGBA PIL Image, or None on failure.
+
+    Failures (non-200 status, network errors) are logged at WARNING level and
+    None is returned so the caller can decide whether to fail or fall back.
+    """
+    try:
+        async with session.get(url, headers={"User-Agent": _USER_AGENT}) as resp:
+            if resp.status != 200:
+                _LOGGER.warning(
+                    "Map tile fetch failed: HTTP %d for %s", resp.status, url
+                )
+                return None
+            data = await resp.read()
+            return Image.open(BytesIO(data)).convert("RGBA")
+    except Exception as exc:
+        _LOGGER.warning(
+            "Map tile fetch error: %s: %s for %s", type(exc).__name__, exc, url
+        )
+        return None
+
+
+def _apply_osm_dark_transform(img: Image.Image) -> Image.Image:
+    """HSV V-invert + feature lift + saturation reduction for the OSM dark variant.
+
+    Step 1: reduce saturation via _OSM_DARK_SATURATION_FACTOR to tone down
+            overly vivid bushland greens compared to a plain HSV invert.
+    Step 2: invert the V channel so bright areas go dark and vice versa.
+    Step 3: feature lift - make dark features (roads, labels) bright so they
+            remain visible on the dark background.
+    """
+    desaturated = ImageEnhance.Color(img).enhance(_OSM_DARK_SATURATION_FACTOR)
+    hsv_arr = np.array(desaturated.convert("HSV")).astype(np.int16)
+    hsv_arr[:, :, 2] = 255 - hsv_arr[:, :, 2]
+    luma = np.array(desaturated.convert("L")).astype(np.int16)
+    feature_lift = 255 - luma
+    hsv_arr[:, :, 2] = np.maximum(hsv_arr[:, :, 2], feature_lift)
+    hsv_arr = hsv_arr.clip(0, 255).astype(np.uint8)
+    h, w = hsv_arr.shape[:2]
+    return Image.frombytes("HSV", (w, h), hsv_arr.tobytes()).convert("RGB").convert("RGBA")
+
+
+# ---------------------------------------------------------------------------
+# Per-style fetch functions
+# ---------------------------------------------------------------------------
+
+async def _fetch_voyager(
+    session: aiohttp.ClientSession, z: int, x: int, y: int
+) -> Image.Image | None:
+    return await _fetch_png(
+        session, f"https://basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}.png"
+    )
+
+
+async def _fetch_osm_standard(
+    session: aiohttp.ClientSession, z: int, x: int, y: int
+) -> Image.Image | None:
+    return await _fetch_png(session, f"https://tile.openstreetmap.org/{z}/{x}/{y}.png")
+
+
+async def _fetch_osm_dark(
+    session: aiohttp.ClientSession, z: int, x: int, y: int
+) -> Image.Image | None:
+    base = await _fetch_osm_standard(session, z, x, y)
+    return _apply_osm_dark_transform(base) if base is not None else None
+
+
+async def _fetch_esri_imagery(
+    session: aiohttp.ClientSession, z: int, x: int, y: int
+) -> Image.Image | None:
+    # Note: ESRI tile URL pattern uses {z}/{y}/{x} - y before x (unlike OSM).
+    base = await _fetch_png(
+        session,
+        f"https://server.arcgisonline.com/ArcGIS/rest/services"
+        f"/World_Imagery/MapServer/tile/{z}/{y}/{x}",
+    )
+    if base is None:
+        return None
+
+    # Overlay layers are nice-to-have: composite what we can, fall back gracefully.
+    roads = await _fetch_png(
+        session,
+        f"https://server.arcgisonline.com/ArcGIS/rest/services"
+        f"/Reference/World_Transportation/MapServer/tile/{z}/{y}/{x}",
+    )
+    labels = await _fetch_png(
+        session,
+        f"https://server.arcgisonline.com/ArcGIS/rest/services"
+        f"/Reference/World_Boundaries_and_Places/MapServer/tile/{z}/{y}/{x}",
+    )
+
+    result = base.copy()
+    if roads is not None:
+        result.alpha_composite(roads)
+    if labels is not None:
+        result.alpha_composite(labels)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+_STYLES: dict[MapStyle, MapStyleDefinition] = {
+    MapStyle.VOYAGER: MapStyleDefinition(
+        style=MapStyle.VOYAGER,
+        display_name="CARTO Voyager",
+        attribution="© CARTO, © OpenStreetMap contributors",
+        fetch_tile=_fetch_voyager,
+    ),
+    MapStyle.OSM_STANDARD: MapStyleDefinition(
+        style=MapStyle.OSM_STANDARD,
+        display_name="OpenStreetMap",
+        attribution="© OpenStreetMap contributors",
+        fetch_tile=_fetch_osm_standard,
+    ),
+    MapStyle.OSM_DARK: MapStyleDefinition(
+        style=MapStyle.OSM_DARK,
+        display_name="OpenStreetMap Dark",
+        attribution="© OpenStreetMap contributors",
+        fetch_tile=_fetch_osm_dark,
+    ),
+    MapStyle.ESRI_IMAGERY: MapStyleDefinition(
+        style=MapStyle.ESRI_IMAGERY,
+        display_name="ESRI World Imagery",
+        attribution="Sources: Esri, Maxar, Earthstar Geographics, and the GIS User Community",
+        fetch_tile=_fetch_esri_imagery,
+    ),
+}
+
+
+def get_style(style: MapStyle | str) -> MapStyleDefinition:
+    """Lookup a MapStyleDefinition by enum or string value.
+
+    Raises ValueError for unrecognised style names.
+    """
+    if isinstance(style, str) and not isinstance(style, MapStyle):
+        try:
+            style = MapStyle(style)
+        except ValueError as exc:
+            raise ValueError(
+                f"Unknown map style: {style!r}. Valid: {[s.value for s in MapStyle]}"
+            ) from exc
+    if style not in _STYLES:
+        raise ValueError(f"Unknown map style: {style!r}")
+    return _STYLES[style]

--- a/tests/unit/radar/test_map_styles.py
+++ b/tests/unit/radar/test_map_styles.py
@@ -1,0 +1,411 @@
+"""Unit tests for map_styles.py - selectable base map style module.
+
+Tests cover:
+- Registry lookup by enum and string
+- Validation / error paths
+- Per-style tile fetch logic (all mocked - no real network calls)
+- OSM Dark transform correctness
+- ESRI multi-layer compositing and URL correctness
+"""
+from __future__ import annotations
+
+from io import BytesIO
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from custom_components.rain_incoming.radar.map_styles import (
+    MapStyle,
+    MapStyleDefinition,
+    _OSM_DARK_SATURATION_FACTOR,
+    _apply_osm_dark_transform,
+    get_style,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_png_bytes(size=(256, 256), color=(100, 150, 200, 255)) -> bytes:
+    """Create a tiny valid RGBA PNG."""
+    img = Image.new("RGBA", size, color)
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class _MockResponse:
+    def __init__(self, status=200, body=b""):
+        self.status = status
+        self._body = body
+
+    async def read(self):
+        return self._body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+
+class _TrackingSession:
+    """Minimal mock aiohttp session that records URLs fetched."""
+
+    def __init__(self, url_to_bytes: dict[str, bytes]) -> None:
+        self._url_to_bytes = url_to_bytes
+        self.calls: list[str] = []
+
+    def get(self, url: str, **kwargs):
+        self.calls.append(url)
+        if url in self._url_to_bytes:
+            return _MockResponse(status=200, body=self._url_to_bytes[url])
+        return _MockResponse(status=404)
+
+
+def _mock_session(url_to_bytes: dict[str, bytes]) -> _TrackingSession:
+    """Build a mock aiohttp session that returns specific bytes per URL."""
+    return _TrackingSession(url_to_bytes)
+
+
+def _calls_made(session: _TrackingSession) -> list[str]:
+    """Return the list of URLs passed to session.get()."""
+    return session.calls
+
+
+# ---------------------------------------------------------------------------
+# Registry lookup tests
+# ---------------------------------------------------------------------------
+
+def test_get_style_by_enum_returns_definition():
+    defn = get_style(MapStyle.OSM_STANDARD)
+    assert isinstance(defn, MapStyleDefinition)
+    assert defn.attribution
+
+
+def test_get_style_by_string_returns_definition():
+    defn = get_style("osm_dark")
+    assert isinstance(defn, MapStyleDefinition)
+    assert defn.style == MapStyle.OSM_DARK
+
+
+def test_get_style_unknown_string_raises():
+    with pytest.raises(ValueError, match="nonexistent"):
+        get_style("nonexistent")
+
+
+def test_all_styles_registered():
+    for style in MapStyle:
+        defn = get_style(style)
+        assert defn.style == style
+
+
+def test_all_attributions_nonempty():
+    expected_substrings = {
+        MapStyle.VOYAGER: "CARTO",
+        MapStyle.OSM_STANDARD: "OpenStreetMap",
+        MapStyle.OSM_DARK: "OpenStreetMap",
+        MapStyle.ESRI_IMAGERY: "Esri",
+    }
+    for style in MapStyle:
+        defn = get_style(style)
+        assert defn.attribution, f"{style} has empty attribution"
+        assert expected_substrings[style] in defn.attribution, (
+            f"{style} attribution missing expected provider. Got: {defn.attribution!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Voyager tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_voyager_fetches_from_correct_url():
+    expected_url = "https://basemaps.cartocdn.com/rastertiles/voyager/7/115/78.png"
+    session = _mock_session({expected_url: _make_png_bytes()})
+
+    defn = get_style(MapStyle.VOYAGER)
+    await defn.fetch_tile(session, 7, 115, 78)
+
+    assert expected_url in _calls_made(session)
+
+
+@pytest.mark.asyncio
+async def test_voyager_returns_rgba_image():
+    url = "https://basemaps.cartocdn.com/rastertiles/voyager/7/115/78.png"
+    session = _mock_session({url: _make_png_bytes()})
+
+    defn = get_style(MapStyle.VOYAGER)
+    result = await defn.fetch_tile(session, 7, 115, 78)
+
+    assert result is not None
+    assert isinstance(result, Image.Image)
+    assert result.mode == "RGBA"
+    assert result.size == (256, 256)
+
+
+@pytest.mark.asyncio
+async def test_voyager_returns_none_on_404():
+    session = _mock_session({})  # all URLs 404
+
+    defn = get_style(MapStyle.VOYAGER)
+    result = await defn.fetch_tile(session, 7, 115, 78)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# OSM Standard tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_osm_standard_fetches_from_correct_url():
+    expected_url = "https://tile.openstreetmap.org/7/115/78.png"
+    session = _mock_session({expected_url: _make_png_bytes()})
+
+    defn = get_style(MapStyle.OSM_STANDARD)
+    await defn.fetch_tile(session, 7, 115, 78)
+
+    assert expected_url in _calls_made(session)
+
+
+@pytest.mark.asyncio
+async def test_osm_standard_returns_rgba_image():
+    url = "https://tile.openstreetmap.org/7/115/78.png"
+    session = _mock_session({url: _make_png_bytes()})
+
+    defn = get_style(MapStyle.OSM_STANDARD)
+    result = await defn.fetch_tile(session, 7, 115, 78)
+
+    assert result is not None
+    assert isinstance(result, Image.Image)
+    assert result.mode == "RGBA"
+    assert result.size == (256, 256)
+
+
+@pytest.mark.asyncio
+async def test_osm_standard_returns_none_on_404():
+    session = _mock_session({})  # all URLs 404
+
+    defn = get_style(MapStyle.OSM_STANDARD)
+    result = await defn.fetch_tile(session, 7, 115, 78)
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# OSM Dark tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_osm_dark_fetches_osm_url():
+    osm_url = "https://tile.openstreetmap.org/7/115/78.png"
+    session = _mock_session({osm_url: _make_png_bytes()})
+
+    defn = get_style(MapStyle.OSM_DARK)
+    await defn.fetch_tile(session, 7, 115, 78)
+
+    assert osm_url in _calls_made(session)
+
+
+@pytest.mark.asyncio
+async def test_osm_dark_applies_hsv_transform():
+    """A mid-tone pale pixel (like OSM land) should become darker after the transform."""
+    # pale beige - like OSM land area. In HSV this has high V.
+    osm_url = "https://tile.openstreetmap.org/7/115/78.png"
+    session = _mock_session({osm_url: _make_png_bytes(color=(200, 180, 150, 255))})
+
+    defn = get_style(MapStyle.OSM_DARK)
+    result = await defn.fetch_tile(session, 7, 115, 78)
+
+    assert result is not None
+    result_arr = np.array(result.convert("HSV"))
+    # The pale beige original has high V (bright). After invert, V should be low (dark).
+    mean_v = result_arr[:, :, 2].mean()
+    original_v = np.array(Image.new("RGB", (256, 256), (200, 180, 150)).convert("HSV"))[:, :, 2].mean()
+    assert mean_v < original_v, (
+        f"OSM dark transform should reduce brightness. "
+        f"Original mean V={original_v:.1f}, result mean V={mean_v:.1f}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_osm_dark_brightens_dark_features():
+    """An all-black tile with dark features should become bright after feature lift."""
+    osm_url = "https://tile.openstreetmap.org/7/115/78.png"
+    # All-black PNG: V=0, so after V-invert V=255, and feature_lift for black luma=0 -> 255
+    session = _mock_session({osm_url: _make_png_bytes(color=(0, 0, 0, 255))})
+
+    defn = get_style(MapStyle.OSM_DARK)
+    result = await defn.fetch_tile(session, 7, 115, 78)
+
+    assert result is not None
+    result_arr = np.array(result.convert("RGB"))
+    # Black inverted = white (V=0 -> V=255, feature_lift 255-0=255)
+    mean_val = result_arr.mean()
+    assert mean_val > 200, (
+        f"All-black tile should become very bright after feature lift. Got mean={mean_val:.1f}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_osm_dark_returns_none_if_base_fails():
+    session = _mock_session({})  # all 404
+
+    defn = get_style(MapStyle.OSM_DARK)
+    result = await defn.fetch_tile(session, 7, 115, 78)
+
+    assert result is None
+
+
+def test_osm_dark_saturation_factor_affects_output():
+    """The saturation factor constant must exist and be < 1.0 (i.e., desaturating)."""
+    assert _OSM_DARK_SATURATION_FACTOR < 1.0, (
+        f"_OSM_DARK_SATURATION_FACTOR should be < 1.0 to reduce saturation, "
+        f"got {_OSM_DARK_SATURATION_FACTOR}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# ESRI Imagery tests
+# ---------------------------------------------------------------------------
+
+def _esri_url(layer: str, z: int, x: int, y: int) -> str:
+    return (
+        f"https://server.arcgisonline.com/ArcGIS/rest/services"
+        f"/{layer}/MapServer/tile/{z}/{y}/{x}"
+    )
+
+
+_ESRI_BASE = "World_Imagery"
+_ESRI_ROADS = "Reference/World_Transportation"
+_ESRI_LABELS = "Reference/World_Boundaries_and_Places"
+
+
+@pytest.mark.asyncio
+async def test_esri_fetches_three_urls():
+    z, x, y = 7, 115, 78
+    urls = {
+        _esri_url(_ESRI_BASE, z, x, y): _make_png_bytes(color=(40, 60, 40, 255)),
+        _esri_url(_ESRI_ROADS, z, x, y): _make_png_bytes(color=(200, 200, 200, 128)),
+        _esri_url(_ESRI_LABELS, z, x, y): _make_png_bytes(color=(255, 255, 255, 200)),
+    }
+    session = _mock_session(urls)
+
+    defn = get_style(MapStyle.ESRI_IMAGERY)
+    await defn.fetch_tile(session, z, x, y)
+
+    called = _calls_made(session)
+    for url in urls:
+        assert url in called, f"Expected {url!r} to be fetched, got {called}"
+
+
+@pytest.mark.asyncio
+async def test_esri_composites_three_layers():
+    """Three distinct-coloured layers composited should show the top layer's colour dominating."""
+    z, x, y = 7, 115, 78
+    # Base: dark green (satellite-ish), Roads: grey semi-transparent, Labels: white mostly-opaque
+    base_png = _make_png_bytes(color=(40, 80, 40, 255))
+    roads_png = _make_png_bytes(color=(180, 180, 180, 100))
+    labels_png = _make_png_bytes(color=(240, 240, 240, 220))
+    urls = {
+        _esri_url(_ESRI_BASE, z, x, y): base_png,
+        _esri_url(_ESRI_ROADS, z, x, y): roads_png,
+        _esri_url(_ESRI_LABELS, z, x, y): labels_png,
+    }
+    session = _mock_session(urls)
+
+    defn = get_style(MapStyle.ESRI_IMAGERY)
+    result = await defn.fetch_tile(session, z, x, y)
+
+    assert result is not None
+    arr = np.array(result.convert("RGB"))
+    mean_r = arr[:, :, 0].mean()
+    mean_g = arr[:, :, 1].mean()
+
+    # Labels layer (high R,G,B) composited last should raise the R channel significantly
+    # above the dark base green (~40 R). With alpha 220/255 the blend pulls heavily toward 240.
+    assert mean_r > 150, (
+        f"Composited result should reflect high-alpha labels overlay. Mean R={mean_r:.1f}"
+    )
+    # Green channel raised too by labels (240), but base was already (80 G)
+    assert mean_g > 150, (
+        f"Green channel should be elevated from labels overlay. Mean G={mean_g:.1f}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_esri_succeeds_without_overlays():
+    """If road/label overlays 404, should still return the base image."""
+    z, x, y = 7, 115, 78
+    base_color = (40, 80, 40, 255)
+    urls = {
+        _esri_url(_ESRI_BASE, z, x, y): _make_png_bytes(color=base_color),
+        # roads and labels intentionally missing -> 404
+    }
+    session = _mock_session(urls)
+
+    defn = get_style(MapStyle.ESRI_IMAGERY)
+    result = await defn.fetch_tile(session, z, x, y)
+
+    assert result is not None, "Should return base image when overlays fail"
+    arr = np.array(result.convert("RGB"))
+    # Result should still look like the base (dark green ~40 R, ~80 G)
+    assert arr[:, :, 0].mean() < 80, "Without overlays, R channel should still be ~base"
+
+
+@pytest.mark.asyncio
+async def test_esri_returns_none_if_base_fails():
+    """If base 404, should return None even if overlays would succeed."""
+    z, x, y = 7, 115, 78
+    urls = {
+        # base missing, overlays present
+        _esri_url(_ESRI_ROADS, z, x, y): _make_png_bytes(color=(200, 200, 200, 128)),
+        _esri_url(_ESRI_LABELS, z, x, y): _make_png_bytes(color=(255, 255, 255, 200)),
+    }
+    session = _mock_session(urls)
+
+    defn = get_style(MapStyle.ESRI_IMAGERY)
+    result = await defn.fetch_tile(session, z, x, y)
+
+    assert result is None, "Should return None when base tile fails"
+
+
+@pytest.mark.asyncio
+async def test_esri_uses_y_x_url_order():
+    """Regression: ESRI URLs must use /{z}/{y}/{x} not /{z}/{x}/{y}."""
+    z, x, y = 7, 115, 78
+    # Correct URL has y=78 before x=115
+    correct_base_url = _esri_url(_ESRI_BASE, z, x, y)
+    assert f"/{z}/{y}/{x}" in correct_base_url, "Helper sanity check"
+
+    # Feed the mock only the correct URL so a wrong-order URL would get a 404
+    session = _mock_session({
+        correct_base_url: _make_png_bytes(),
+        _esri_url(_ESRI_ROADS, z, x, y): _make_png_bytes(),
+        _esri_url(_ESRI_LABELS, z, x, y): _make_png_bytes(),
+    })
+
+    defn = get_style(MapStyle.ESRI_IMAGERY)
+    result = await defn.fetch_tile(session, z, x, y)
+
+    assert result is not None, (
+        "ESRI fetch should succeed with correct y/x URL order. "
+        "If this fails, the implementation may be using x/y order."
+    )
+
+    called = _calls_made(session)
+    for url in called:
+        if "arcgisonline" in url:
+            # Parse the last three path segments - should be z/y/x
+            parts = url.rstrip("/").split("/")
+            tile_z, tile_y, tile_x = parts[-3], parts[-2], parts[-1]
+            assert tile_y == str(y), (
+                f"ESRI URL should have y={y} before x={x}, got .../{tile_z}/{tile_y}/{tile_x} in {url}"
+            )
+            assert tile_x == str(x), (
+                f"ESRI URL should have x={x} last, got .../{tile_z}/{tile_y}/{tile_x} in {url}"
+            )


### PR DESCRIPTION
## Summary
First of 3 sequential PRs implementing selectable base map styles for the rain_incoming integration (parent task #83). This PR is **purely additive** — new module and tests, no changes to existing files. PR 2 wires it into `composite.py`, PR 3 exposes it via config flow.

## What's added

### `custom_components/rain_incoming/radar/map_styles.py`
- `MapStyle` StrEnum with four styles: `VOYAGER`, `OSM_STANDARD`, `OSM_DARK`, `ESRI_IMAGERY`
- `MapStyleDefinition` frozen dataclass: `style`, `display_name`, `attribution`, `fetch_tile` async callable
- `get_style(style: MapStyle | str) -> MapStyleDefinition` lookup accepting both enum and string

### Four style implementations
- **Voyager** (default): single GET to CARTO voyager tiles (current production behaviour preserved)
- **OSM Standard**: single GET to tile.openstreetmap.org
- **OSM Dark**: fetches OSM then applies saturation reduction (`_OSM_DARK_SATURATION_FACTOR = 0.75`) + HSV V-invert + feature lift. Gives a gentle dark-mode aesthetic with water staying blue, land going dark, and road/label features brightening to near-white
- **ESRI Imagery**: fetches World_Imagery base then alpha-composites World_Transportation (roads) and World_Boundaries_and_Places (labels) overlays. Note y/x URL order is different from OSM's x/y

### Attribution strings (per provider terms)
- Voyager: `© CARTO, © OpenStreetMap contributors`
- OSM Standard / OSM Dark: `© OpenStreetMap contributors`
- ESRI Imagery: `Sources: Esri, Maxar, Earthstar Geographics, and the GIS User Community`

## Design decisions worth flagging

1. **Voyager stays as default** (user's explicit instruction). No behavioural change for existing users. New styles are purely opt-in via PR 3's config flow.
2. **`_OSM_DARK_SATURATION_FACTOR` is a module constant** (currently 0.75) so future tuning is a one-line change. User noted the original HSV V-invert's greens felt too saturated — 0.75 is the starting point based on visual comparison.
3. **OSM Dark transform uses `Image.frombytes("HSV", ...)` not `Image.fromarray(..., mode="HSV")`** to avoid Pillow 13's (2026-10-15) removal of the `mode=` parameter. Test-expert caught this before merge.
4. **ESRI fetch is overlay-tolerant**: if World_Transportation or World_Boundaries 404s at a given zoom, the base is returned without those overlays rather than failing the whole fetch.
5. **`_fetch_png` is private and doesn't currently use `http_retry.py`** — test-expert flagged this as a follow-up to address in PR 2 (wrap `fetch_with_retry`, catch 404 specifically to preserve overlay-fallback logic).

## Tests
21 new unit tests in `tests/unit/radar/test_map_styles.py`:
- Style lookup (by enum, by string, unknown, all-registered, attributions-present)
- Per-style fetch behaviour (correct URL, RGBA return, 404 handling)
- OSM Dark transform load-bearing assertions (bright pixels darkened, dark pixels brightened via feature lift, saturation constant < 1.0)
- ESRI specific: three URLs fetched, three layers composited, works with missing overlays, fails if base fails, y/x URL order regression guard

All tests use mocked aiohttp sessions via a custom `_TrackingSession` helper. No real network calls.

## TDD evidence
Three load-bearing tests were red-first verified against broken implementations:
- `test_osm_dark_applies_hsv_transform` failed with pass-through impl (`200.0 < 200.0` assertion error)
- `test_osm_dark_brightens_dark_features` failed with pass-through impl on all-black input (`0.0 > 200` error)
- `test_esri_composites_three_layers` failed with no-overlay impl (`40.0 > 150` error)

All pass with the real implementation.

## Test plan
- [x] 322 unit + integration tests pass locally (was 301 — 21 new)
- [x] Hardened pre-push hook (PR #21) all 3 gates green
- [x] Test-expert approved after Pillow deprecation fix + minor polish items
- [x] Scope discipline: exactly 2 files touched, nothing else

## What comes next
- **PR 2** (`feat/map-style-integration`, task #114): refactor `composite.py` to use the registry, add bottom-right attribution rendering, add `fetch_with_retry` wrap, add render-time location-name truncation, integrate the new styles into `render_animated_composite`
- **PR 3** (`feat/map-style-config-flow`, task #115): add `map_style` selector to config flow + options flow, migration for existing entries, 30-char location name validator to prevent attribution/label overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>