### PR TITLE
fix: replace async_listen_once with async_at_started to prevent ValueError on unload

### DIFF
--- a/custom_components/rain_incoming/__init__.py
+++ b/custom_components/rain_incoming/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
-from homeassistant.core import Event, HomeAssistant
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.start import async_at_started
 
 from .const import DOMAIN
 from .coordinator import RainDetectorCoordinator
@@ -17,20 +17,19 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # The first radar fetch can take 10-30+ seconds. Instead, set up
     # platforms immediately (sensors show unavailable) and schedule the
     # first data fetch after HA has fully started.
+    #
+    # async_at_started handles both cases (already started vs. waiting for startup)
+    # and returns an unsubscribe callable that is safe to call at any time - including
+    # after the listener has already fired and auto-removed itself. This avoids a
+    # ValueError from the previous async_listen_once pattern where on_unload would
+    # attempt to remove an already-removed listener.
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
-    async def _async_first_refresh(_event: Event) -> None:
+    async def _do_first_refresh(_hass: HomeAssistant) -> None:
         await coordinator.async_request_refresh()
 
-    # If HA is already running (e.g. config entry reloaded at runtime),
-    # trigger the refresh immediately. Otherwise wait for startup to finish.
-    if hass.is_running:
-        await coordinator.async_request_refresh()
-    else:
-        entry.async_on_unload(
-            hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_first_refresh)
-        )
+    entry.async_on_unload(async_at_started(hass, _do_first_refresh))
 
     return True
 

--- a/tests/integration/test_no_unexpected_warnings.py
+++ b/tests/integration/test_no_unexpected_warnings.py
@@ -15,7 +15,8 @@ import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
+from homeassistant.core import CoreState, HomeAssistant
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.rain_incoming.const import DOMAIN
@@ -88,4 +89,63 @@ async def test_no_unexpected_warnings_from_integration(hass: HomeAssistant, capl
     assert not unexpected, (
         f"Found {len(unexpected)} unexpected warning(s) from rain_incoming:\n"
         + "\n".join(f"  [{r.levelname}] {r.name}: {r.getMessage()}" for r in unexpected)
+    )
+
+
+@pytest.mark.asyncio
+async def test_setup_unload_does_not_emit_value_error(hass: HomeAssistant, caplog):
+    """Setting up then unloading the entry should not log ValueError from listener cleanup.
+
+    Regression test for the async_listen_once double-removal bug: when the entry is
+    set up before HA has fully started, a once-listener is registered for
+    EVENT_HOMEASSISTANT_STARTED. The listener auto-removes itself when it fires.
+    When the entry is later unloaded, async_on_unload calls the cleanup callable a
+    second time - against an already-removed listener - raising ValueError.
+
+    This test exercises that path by temporarily making hass.is_running return False
+    during async_setup_entry, so the pre-startup branch is taken.
+    """
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+        },
+        entry_id="test_value_error_check",
+    )
+    entry.add_to_hass(hass)
+
+    # Capture errors from homeassistant.core where the ValueError would surface.
+    with caplog.at_level(logging.ERROR, logger="homeassistant"):
+        with patch(
+            "custom_components.rain_incoming.coordinator.RainDetectorCoordinator._async_update_data",
+            new=AsyncMock(return_value=MOCK_RESULT_NO_RAIN),
+        ):
+            # Force hass.is_running to False during setup so the once-listener branch fires.
+            original_state = hass.state
+            hass.set_state(CoreState.not_running)
+            try:
+                await hass.config_entries.async_setup(entry.entry_id)
+            finally:
+                hass.set_state(original_state)
+
+            # Fire EVENT_HOMEASSISTANT_STARTED so the once-listener fires and auto-removes.
+            hass.bus.async_fire(EVENT_HOMEASSISTANT_STARTED)
+            await hass.async_block_till_done()
+
+            # Unload: on_unload callbacks fire, including the now-stale listener cleanup.
+            # With the bug, this raises ValueError: list.remove(x): x not in list.
+            await hass.config_entries.async_unload(entry.entry_id)
+            await hass.async_block_till_done()
+
+    value_errors = [
+        r for r in caplog.records
+        if r.levelno >= logging.ERROR and (
+            "list.remove" in r.getMessage() or "unknown job listener" in r.getMessage()
+        )
+    ]
+    assert not value_errors, (
+        "Expected no ValueError from listener cleanup on unload, got: "
+        + str([r.getMessage() for r in value_errors])
     )


### PR DESCRIPTION
## Summary
Fixes a benign-but-noisy `ValueError: list.remove(x): x not in list` from `homeassistant.core` that fires on every config entry reload (including the v1→v2 migration reload that ran when map style PRs landed).

## Root cause
\`__init__.py\` wrapped \`hass.bus.async_listen_once(...)\` in \`entry.async_on_unload(...)\`. The once-listener auto-removes itself from the bus when it fires (HA started). Later, when the config entry is unloaded, \`async_on_unload\` calls the cleanup callable AGAIN, which tries to remove the (already-removed) listener and raises:

\`\`\`
ValueError: list.remove(x): x not in list
Unable to remove unknown job listener (<Job onetime listen homeassistant_started <function async_setup_entry.<locals>._async_first_refresh ...>>)
\`\`\`

The error appears in the user's HA logs on every config entry reload but never breaks anything functional — the listener was successfully cleaned up when it fired. It's just spammy and confusing.

## Fix
Replaced with \`homeassistant.helpers.start.async_at_started\`. This helper handles both startup states (already-started → run immediately; not-started → register a once-listener) and returns an unsubscribe callable that's idempotent — safe to call regardless of whether the listener has already fired.

The old \`if hass.is_running: ... else: ...\` branching is removed entirely; \`async_at_started\` handles both cases internally.

## Why existing tests didn't catch this
\`pytest-homeassistant-custom-component\` initializes \`hass\` with \`CoreState.running\`, so \`hass.is_running\` was True in every existing test, and the buggy \`else\` branch never executed. Real users hit the bug because real HA setup runs the integration before \`EVENT_HOMEASSISTANT_STARTED\` fires, taking the not-running path.

## TDD trail
- Wrote regression test FIRST. The test forces \`hass.set_state(CoreState.not_running)\` during \`async_setup\` to exercise the buggy code path that tests previously skipped.
- Test FAILED against unmodified code with: \`AssertionError: Expected no ValueError from listener cleanup on unload, got: ['Unable to remove unknown job listener ...']\`
- Applied the \`async_at_started\` fix
- Test PASSED
- The new test closes a real coverage gap — the not-running setup path was completely untested before.

## Test plan
- [x] 323 unit + integration tests pass locally (322 → 323, +1 new regression test)
- [x] Hardened pre-push hook all 3 gates green
- [x] Test-expert APPROVED — verified async_at_started's idempotency directly from HA source, walked through the regression test mechanics
- [x] Scope discipline: 2 files touched (\`__init__.py\`, \`test_no_unexpected_warnings.py\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>