### PR TITLE
docs: add DCO sign-off workflow + CONTRIBUTING updates (licensing intent, AI disclosure)

### DIFF
--- a/.github/workflows/dco.yml
+++ b/.github/workflows/dco.yml
@@ -1,0 +1,46 @@
+name: DCO
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Minimal permissions: this workflow only reads commits to check sign-offs.
+# Explicit scope to satisfy CodeQL Workflow-permissions best practice and
+# avoid the broad default GITHUB_TOKEN.
+permissions:
+  contents: read
+
+jobs:
+  dco-check:
+    name: Verify DCO sign-off
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Check sign-offs
+        run: |
+          BASE="${{ github.event.pull_request.base.sha }}"
+          HEAD="${{ github.event.pull_request.head.sha }}"
+          UNSIGNED=""
+          while IFS= read -r line; do
+            sha="${line%% *}"
+            subject="${line#* }"
+            if ! git show -s --format='%B' "$sha" | grep -q '^Signed-off-by:'; then
+              UNSIGNED="$UNSIGNED$sha $subject"$'\n'
+            fi
+          done < <(git log "$BASE..$HEAD" --no-merges --format='%H %s')
+          if [ -n "$UNSIGNED" ]; then
+            echo "::error::Found commits without Signed-off-by line:"
+            echo "$UNSIGNED"
+            echo ""
+            echo "Add sign-off to a commit with:"
+            echo "  git commit -s --amend --no-edit"
+            echo ""
+            echo "For multiple unsigned commits:"
+            echo "  git rebase -i --signoff main"
+            echo ""
+            echo "See CONTRIBUTING.md > Sign your commits (DCO)"
+            exit 1
+          fi
+          echo "All commits signed off."

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,12 @@ Thanks for your interest in contributing! This integration detects approaching r
 
 **Quality bar**: resilience, observability, and thorough testing are not optional extras. PRs are expected to maintain the same standard as the existing code.
 
+## AI-assisted development
+
+This project has been developed with substantial AI assistance (Claude Opus and Sonnet) under direct human direction. All architectural decisions, code review, test discipline, and final approvals are made by the human maintainer. Tests, documentation, and production code are reviewed for correctness regardless of how they were written.
+
+Contributions are welcome whether or not you use AI tools. The same DCO sign-off process applies either way - by signing off, you confirm you have the right to submit the contribution, which includes responsibility for any AI-assisted portions.
+
 ## Prerequisites
 
 - Python 3.12+ (via [pyenv](https://github.com/pyenv/pyenv) recommended)
@@ -123,12 +129,50 @@ We follow the [Kubernetes PR best practices](https://github.com/kubernetes/commu
 
 All PRs require a green CI build and at least one approving review before merge.
 
+## Sign your commits (DCO)
+
+This project uses the [Developer Certificate of Origin](https://developercertificate.org/). Every commit must include a `Signed-off-by:` line proving you have the right to contribute the work under this project's licence.
+
+The easiest way to sign off is to use `git commit -s` (or `--signoff`):
+
+```bash
+git commit -s -m "Add support for Lake Margaret radar coverage"
+```
+
+For an existing commit:
+
+```bash
+git commit -s --amend --no-edit
+```
+
+For multiple unsigned commits in a branch:
+
+```bash
+git rebase -i --signoff main
+```
+
+The DCO GitHub Actions check will block merges with unsigned commits. By signing off, you affirm:
+
+1. The contribution is your own work, OR
+2. The contribution is based on prior work covered by an appropriate open source licence and you have the right to submit it under that licence, OR
+3. The contribution was provided to you by someone who certified one of the above and you are not modifying it.
+
+The full DCO text is at [developercertificate.org](https://developercertificate.org/). It's a short, plain-English statement.
+
 ## Commit messages
 
 - Start with what changed, not what you did ("Add cell tracking" not "I added cell tracking")
 - Keep the first line under 72 characters
 - Use the body for why, not what (the diff shows what)
 - Reference the GitHub issue if related (e.g. "Fix arrival time for overhead rain (#42)")
+
+## Licensing intent
+
+This project is released under the MIT Licence (see [LICENSE](LICENSE)). The maintainer reserves the right to dual-licence or relicence the project under other terms (including commercial licences) in the future.
+
+By contributing under the DCO, you acknowledge that your contributions may be included in such relicensed versions of the project. Forks and non-commercial redistribution under the existing MIT terms are explicitly welcome regardless of any future relicensing of this repository - the MIT version of any commit you've seen will always remain available under MIT.
+
+If you'd prefer your contribution NOT be part of any future relicensed version, please open a discussion before submitting the PR.
 
 ## References
 


### PR DESCRIPTION
## Summary
Adds Developer Certificate of Origin (DCO) enforcement plus three new CONTRIBUTING.md sections to set clear expectations for contributors and protect the project's future licensing flexibility.

## What's added

### `.github/workflows/dco.yml`
Self-contained bash workflow that runs on every PR and validates each commit has a `Signed-off-by:` line. Uses raw `git log` checks rather than depending on a third-party action — keeps it transparent and stable.

If a commit lacks sign-off, the workflow fails with clear instructions for fixing (`git commit -s --amend --no-edit` or `git rebase -i --signoff main`).

### CONTRIBUTING.md additions

**`Sign your commits (DCO)`** — explains the DCO process, the three things you affirm by signing off, and how to add sign-offs to existing commits. Inserted after the Pull Requests section.

**`Licensing intent`** — explicitly reserves the maintainer's right to dual-licence or relicence the project under other terms (including commercial licences). By contributing under the DCO, contributors acknowledge their work may be included in such relicensed versions. Forks under existing MIT terms remain explicitly welcome regardless of any future relicensing.

**`AI-assisted development`** — discloses that the project was built with substantial AI assistance (Claude) under human direction. Documents that all architectural decisions, code review, and final approvals are human-driven. Addresses transparency for any future IP diligence.

## Why
The user wants to keep the door open for future relicensing or sale of the project (potential mobile app future, commercial interest, etc) while maintaining low contribution friction. DCO is the standard tool for this:
- **Contributors**: zero friction (`git commit -s` adds the line, takes 1 second)
- **Maintainer**: every contribution is provably submitted with the right to do so, and the licensing intent section gives implicit consent for future relicensing
- **Open source culture**: less aggressive than a CLA (no separate document signing), accepted by the broader OSS community as the lightweight version of a contributor agreement

## What's not included
- **No CLA**: too much friction for a community HA integration
- **No GitHub App marketplace install**: workflow is self-contained in the repo, no external dependencies
- **No production code changes**: docs + CI workflow only

## Test plan
- [x] YAML workflow validated with `yaml.safe_load`
- [x] 322 unit + integration tests still pass (no production code touched)
- [x] Hardened pre-push hook all 3 gates green
- [x] **This PR's own commit is signed off** — practising what it preaches. The workflow it adds will check itself once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Signed-off-by: Andrew Brainwood <andrew.brainwood@gmail.com>