### PR TITLE
recover: re-target merged map style integration + config flow PRs onto main

### DIFF
--- a/custom_components/rain_incoming/__init__.py
+++ b/custom_components/rain_incoming/__init__.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EVENT_HOMEASSISTANT_STARTED
 from homeassistant.core import Event, HomeAssistant
 
-from .const import DOMAIN
+from .const import CONF_MAP_STYLE, DOMAIN
 from .coordinator import RainDetectorCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 PLATFORMS = ["binary_sensor", "image", "sensor"]
 
@@ -30,6 +34,30 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     else:
         entry.async_on_unload(
             hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_first_refresh)
+        )
+
+    return True
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Migrate config entries to the current schema version.
+
+    v1 -> v2: add map_style="voyager" to entry.data.
+    Long location_name values are preserved as-is; PR2's render-time truncation
+    handles display, and the validator only applies to new input via the flows.
+    """
+    _LOGGER.debug(
+        "Migrating Rain Incoming config entry %s from version %d",
+        entry.entry_id, entry.version,
+    )
+
+    if entry.version == 1:
+        new_data = dict(entry.data)
+        new_data.setdefault(CONF_MAP_STYLE, "voyager")
+        hass.config_entries.async_update_entry(entry, data=new_data, version=2)
+        _LOGGER.info(
+            "Migrated Rain Incoming entry %s from v1 to v2: added map_style=voyager",
+            entry.entry_id,
         )
 
     return True

--- a/custom_components/rain_incoming/config_flow.py
+++ b/custom_components/rain_incoming/config_flow.py
@@ -4,15 +4,40 @@ import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry, ConfigFlow, ConfigFlowResult, OptionsFlow
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
 from homeassistant.core import callback
+from homeassistant.helpers.selector import (
+    SelectSelector,
+    SelectSelectorConfig,
+    SelectSelectorMode,
+)
 
 from .const import (
     CONF_LOCATION_NAME,
     CONF_LOOKAHEAD_MINUTES,
+    CONF_MAP_STYLE,
     DEFAULT_LOOKAHEAD_MINUTES,
     DOMAIN,
+    MAX_LOCATION_NAME_CHARS,
     MAX_LOOKAHEAD_MINUTES,
     MIN_LOOKAHEAD_MINUTES,
 )
+
+_VALID_MAP_STYLES = ["voyager", "osm_standard", "osm_dark", "esri_imagery"]
+_DEFAULT_MAP_STYLE = "voyager"
+
+
+def _validate_map_style(value: str) -> str:
+    if value not in _VALID_MAP_STYLES:
+        raise vol.Invalid(f"Invalid map style: {value!r}")
+    return value
+
+
+def _validate_location_name(value: str) -> str:
+    if len(value) > MAX_LOCATION_NAME_CHARS:
+        raise vol.Invalid(
+            f"Location name must be {MAX_LOCATION_NAME_CHARS} characters or fewer"
+            " (avoids overlap with map attribution on the bottom of the composite)."
+        )
+    return value
 
 
 def _validate_input(user_input: dict) -> dict[str, str]:
@@ -27,6 +52,34 @@ def _validate_input(user_input: dict) -> dict[str, str]:
         errors[CONF_LONGITUDE] = "invalid_longitude"
     elif not (MIN_LOOKAHEAD_MINUTES <= lookahead <= MAX_LOOKAHEAD_MINUTES):
         errors[CONF_LOOKAHEAD_MINUTES] = "invalid_lookahead"
+
+    location_name = user_input.get(CONF_LOCATION_NAME, "")
+    if location_name and len(location_name) > MAX_LOCATION_NAME_CHARS:
+        errors[CONF_LOCATION_NAME] = "location_name_too_long"
+
+    map_style = user_input.get(CONF_MAP_STYLE, _DEFAULT_MAP_STYLE)
+    if map_style not in _VALID_MAP_STYLES:
+        errors[CONF_MAP_STYLE] = "invalid_map_style"
+
+    return errors
+
+
+def _validate_options_input(user_input: dict) -> dict[str, str]:
+    """Validate options flow input (no lat/lon)."""
+    errors: dict[str, str] = {}
+
+    lookahead = user_input.get(CONF_LOOKAHEAD_MINUTES)
+    if lookahead is not None and not (MIN_LOOKAHEAD_MINUTES <= lookahead <= MAX_LOOKAHEAD_MINUTES):
+        errors[CONF_LOOKAHEAD_MINUTES] = "invalid_lookahead"
+
+    location_name = user_input.get(CONF_LOCATION_NAME, "")
+    if location_name and len(location_name) > MAX_LOCATION_NAME_CHARS:
+        errors[CONF_LOCATION_NAME] = "location_name_too_long"
+
+    map_style = user_input.get(CONF_MAP_STYLE, _DEFAULT_MAP_STYLE)
+    if map_style not in _VALID_MAP_STYLES:
+        errors[CONF_MAP_STYLE] = "invalid_map_style"
+
     return errors
 
 
@@ -44,6 +97,7 @@ def _build_schema(
     default_lon: float,
     default_lookahead: int = DEFAULT_LOOKAHEAD_MINUTES,
     default_location_name: str = "",
+    default_map_style: str = _DEFAULT_MAP_STYLE,
 ) -> vol.Schema:
     return vol.Schema(
         {
@@ -51,6 +105,33 @@ def _build_schema(
             vol.Required(CONF_LONGITUDE, default=default_lon): vol.Coerce(float),
             vol.Required(CONF_LOOKAHEAD_MINUTES, default=default_lookahead): vol.Coerce(int),
             vol.Optional(CONF_LOCATION_NAME, default=default_location_name): str,
+            vol.Optional(CONF_MAP_STYLE, default=default_map_style): SelectSelector(
+                SelectSelectorConfig(
+                    options=list(_VALID_MAP_STYLES),
+                    mode=SelectSelectorMode.DROPDOWN,
+                    translation_key="map_style",
+                )
+            ),
+        }
+    )
+
+
+def _build_options_schema(
+    default_lookahead: int = DEFAULT_LOOKAHEAD_MINUTES,
+    default_location_name: str = "",
+    default_map_style: str = _DEFAULT_MAP_STYLE,
+) -> vol.Schema:
+    return vol.Schema(
+        {
+            vol.Required(CONF_LOOKAHEAD_MINUTES, default=default_lookahead): vol.Coerce(int),
+            vol.Optional(CONF_LOCATION_NAME, default=default_location_name): str,
+            vol.Optional(CONF_MAP_STYLE, default=default_map_style): SelectSelector(
+                SelectSelectorConfig(
+                    options=list(_VALID_MAP_STYLES),
+                    mode=SelectSelectorMode.DROPDOWN,
+                    translation_key="map_style",
+                )
+            ),
         }
     )
 
@@ -58,7 +139,7 @@ def _build_schema(
 class RainIncomingConfigFlow(ConfigFlow, domain=DOMAIN):
     """Config flow for Rain Incoming."""
 
-    VERSION = 1
+    VERSION = 2
 
     @staticmethod
     @callback
@@ -73,6 +154,9 @@ class RainIncomingConfigFlow(ConfigFlow, domain=DOMAIN):
         if user_input is not None:
             errors = _validate_input(user_input)
             if not errors:
+                # Normalise: ensure map_style is present with default
+                if CONF_MAP_STYLE not in user_input:
+                    user_input = {**user_input, CONF_MAP_STYLE: _DEFAULT_MAP_STYLE}
                 lat = user_input[CONF_LATITUDE]
                 lon = user_input[CONF_LONGITUDE]
                 await self.async_set_unique_id(f"{lat:.4f}_{lon:.4f}")
@@ -92,7 +176,10 @@ class RainIncomingConfigFlow(ConfigFlow, domain=DOMAIN):
 
 
 class RainIncomingOptionsFlow(OptionsFlow):
-    """Options flow to reconfigure location and lookahead after setup."""
+    """Options flow: change map_style, location_name, and lookahead post-install.
+
+    Latitude and longitude are install-time properties and are NOT editable here.
+    """
 
     def __init__(self, config_entry: ConfigEntry) -> None:
         self._config_entry = config_entry
@@ -103,23 +190,40 @@ class RainIncomingOptionsFlow(OptionsFlow):
         errors: dict[str, str] = {}
 
         if user_input is not None:
-            errors = _validate_input(user_input)
+            errors = _validate_options_input(user_input)
             if not errors:
-                # Update the config entry data with new values
+                # Merge the new options into entry.data so the title reflects changes.
+                merged_data = dict(self._config_entry.data)
+                if CONF_LOCATION_NAME in user_input:
+                    merged_data[CONF_LOCATION_NAME] = user_input[CONF_LOCATION_NAME]
+                if CONF_LOOKAHEAD_MINUTES in user_input:
+                    merged_data[CONF_LOOKAHEAD_MINUTES] = user_input[CONF_LOOKAHEAD_MINUTES]
+
                 self.hass.config_entries.async_update_entry(
                     self._config_entry,
-                    data=user_input,
-                    title=_build_title(user_input),
+                    data=merged_data,
+                    title=_build_title({**merged_data}),
                 )
-                await self.hass.config_entries.async_reload(self._config_entry.entry_id)
-                return self.async_create_entry(data={})
+                # Trigger reload so the coordinator picks up the new style immediately.
+                self.hass.config_entries.async_schedule_reload(self._config_entry.entry_id)
+                return self.async_create_entry(data=user_input)
 
-        current = self._config_entry.data
-        schema = _build_schema(
-            current.get(CONF_LATITUDE, self.hass.config.latitude),
-            current.get(CONF_LONGITUDE, self.hass.config.longitude),
-            current.get(CONF_LOOKAHEAD_MINUTES, DEFAULT_LOOKAHEAD_MINUTES),
-            current.get(CONF_LOCATION_NAME, ""),
+        # Pre-populate from current options (preferred) then data (fallback).
+        current_options = self._config_entry.options
+        current_data = self._config_entry.data
+        schema = _build_options_schema(
+            default_lookahead=current_options.get(
+                CONF_LOOKAHEAD_MINUTES,
+                current_data.get(CONF_LOOKAHEAD_MINUTES, DEFAULT_LOOKAHEAD_MINUTES),
+            ),
+            default_location_name=current_options.get(
+                CONF_LOCATION_NAME,
+                current_data.get(CONF_LOCATION_NAME, ""),
+            ),
+            default_map_style=current_options.get(
+                CONF_MAP_STYLE,
+                current_data.get(CONF_MAP_STYLE, _DEFAULT_MAP_STYLE),
+            ),
         )
         return self.async_show_form(
             step_id="init", data_schema=schema, errors=errors

--- a/custom_components/rain_incoming/const.py
+++ b/custom_components/rain_incoming/const.py
@@ -3,6 +3,10 @@ DOMAIN = "rain_incoming"
 # Config keys (user-facing)
 CONF_LOCATION_NAME = "location_name"
 CONF_LOOKAHEAD_MINUTES = "lookahead_minutes"
+CONF_MAP_STYLE = "map_style"
+
+# Location name display limit (chars). Longer names overlap the attribution line.
+MAX_LOCATION_NAME_CHARS = 30
 
 # Lookahead bounds
 DEFAULT_LOOKAHEAD_MINUTES = 60

--- a/custom_components/rain_incoming/coordinator.py
+++ b/custom_components/rain_incoming/coordinator.py
@@ -36,6 +36,7 @@ from .const import (
     BACKOFF_MAX_SECONDS,
     BACKOFF_MULTIPLIER,
     CONF_LOOKAHEAD_MINUTES,
+    CONF_MAP_STYLE,
     DEFAULT_LOOKAHEAD_MINUTES,
     INTENSITY_THRESHOLD,
     MAX_ANGULAR_VARIANCE_RADIANS,
@@ -148,6 +149,14 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
         # Frame cache: path -> RainViewerFrame with pre-fetched grid.
         # Avoids re-fetching tile grids for frames that haven't changed between polls.
         self._frame_cache: dict[str, object] = {}
+
+    @property
+    def map_style(self) -> str:
+        """Return the active map style, reading options first then data then default."""
+        return self._entry.options.get(
+            CONF_MAP_STYLE,
+            self._entry.data.get(CONF_MAP_STYLE, "voyager"),
+        )
 
     async def async_save_clutter_map(self) -> None:
         """Persist the clutter map to disk. Called on HA shutdown."""

--- a/custom_components/rain_incoming/image.py
+++ b/custom_components/rain_incoming/image.py
@@ -133,9 +133,11 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
         conf_maps = self.coordinator.confidence_maps or None
         location_name = data.get(CONF_LOCATION_NAME) or None
 
+        map_style = self.coordinator.map_style
+
         _LOGGER.debug(
-            "Radar %dkm: rendering %d frames for %s",
-            self._radius_km, len(frame_paths), location_name or "default location",
+            "Radar %dkm: rendering %d frames for %s (style=%s)",
+            self._radius_km, len(frame_paths), location_name or "default location", map_style,
         )
         try:
             self._cached_image = await render_animated_composite(
@@ -150,6 +152,7 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
                 location_name=location_name,
                 session=session,
                 run_in_executor=self.hass.async_add_executor_job,
+                map_style=map_style,
             )
             self._cached_frame_path = frame_path
             _LOGGER.debug(

--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import asyncio
 import logging
 import math
-import os
 from datetime import datetime
 from io import BytesIO
 
@@ -19,6 +18,7 @@ from ..providers.rainviewer import (
     TILE_SIZE,
 )
 from .geo import lat_lon_to_tile
+from .map_styles import MapStyle, MapStyleDefinition, get_style
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -31,9 +31,6 @@ _PRECIP_RGB = np.array(
 # Maximum L2 colour distance to accept a pixel as precipitation.
 _FILTER_MAX_COLOUR_DISTANCE = 30.0
 
-_MAP_TILE_BASE = os.environ.get(
-    "MAP_TILE_URL", "https://basemaps.cartocdn.com/rastertiles/voyager"
-)
 _RENDER_COLOUR_SCHEME = 2
 _RAINVIEWER_TILE_BASE = TILE_BASE_URL
 
@@ -41,8 +38,8 @@ _CROSSHAIR_RADIUS = 8
 _CROSSHAIR_LINE_LENGTH = 16
 _CROSSHAIR_LINE_GAP = 12
 
-# Module-level cache for static map tiles: (zoom, x, y) -> RGBA Image
-_map_tile_cache: dict[tuple[int, int, int], Image.Image] = {}
+# Module-level cache for static map tiles: (style, zoom, x, y) -> RGBA Image
+_map_tile_cache: dict[tuple, Image.Image] = {}
 
 # Module-level cache for radar tiles: (frame_path, zoom, x, y, scheme) -> RGBA Image
 # The cache key includes frame_path, so stale data can never be served.
@@ -211,20 +208,37 @@ async def _fetch_tile(session: aiohttp.ClientSession, url: str) -> Image.Image:
 
 
 async def _fetch_map_tile(
-    session: aiohttp.ClientSession, zoom: int, tx: int, ty: int,
-) -> Image.Image:
-    """Fetch a map tile, using the module-level cache for hits."""
-    key = (zoom, tx, ty)
-    cached = _map_tile_cache.get(key)
+    session: aiohttp.ClientSession,
+    zoom: int,
+    tx: int,
+    ty: int,
+    style_def: MapStyleDefinition | None = None,
+) -> Image.Image | None:
+    """Fetch a map tile using the given style, with module-level cache for hits.
+
+    style_def defaults to VOYAGER if not provided (preserves previous behaviour).
+    """
+    if style_def is None:
+        style_def = get_style(MapStyle.VOYAGER)
+
+    # Cache key includes style so different styles don't share stale tiles.
+    cache_key = (style_def.style, zoom, tx, ty)
+    cached = _map_tile_cache.get(cache_key)  # type: ignore[arg-type]
     if cached is not None:
         return cached
 
-    url = f"{_MAP_TILE_BASE}/{zoom}/{tx}/{ty}.png"
-    tile = await _fetch_tile(session, url)
-    # Boost saturation for richer land/water colours
-    from PIL import ImageEnhance
-    tile = ImageEnhance.Color(tile).enhance(1.8)
-    _map_tile_cache[key] = tile
+    tile = await style_def.fetch_tile(session, zoom, tx, ty)
+    if tile is None:
+        return None
+
+    # Voyager benefits from a saturation boost for richer land/water colours.
+    # Other styles manage their own post-processing (e.g. OSM Dark applies its
+    # own transform inside _fetch_osm_dark).
+    if style_def.style == MapStyle.VOYAGER:
+        from PIL import ImageEnhance
+        tile = ImageEnhance.Color(tile).enhance(1.8)
+
+    _map_tile_cache[cache_key] = tile  # type: ignore[index]
     return tile
 
 
@@ -238,9 +252,13 @@ def build_frame_label(
 
     Format: "Location  DD/MM/YY  HH:MM TZ  Rangekm"
     Location is omitted if not set.
+    Location names > 30 chars are truncated to 29 chars + ellipsis as a
+    render-time safety net (config validation is PR 3's job).
     """
     parts = []
     if location_name:
+        if len(location_name) > 30:
+            location_name = location_name[:29] + "\u2026"
         parts.append(location_name)
     if timestamp is not None:
         tz_label = timestamp.strftime("%Z") or tz_name or "UTC"
@@ -257,7 +275,7 @@ def _draw_frame_label(
     radius_km: int,
     location_name: str | None = None,
 ) -> None:
-    """Draw the BOM-style label in the bottom-left corner of a frame."""
+    """Draw the BOM-style label in the top-left corner of a frame."""
     label = build_frame_label(timestamp, tz_name, radius_km, location_name)
     draw = ImageDraw.Draw(img)
     try:
@@ -265,11 +283,9 @@ def _draw_frame_label(
     except TypeError:
         font = ImageFont.load_default()
 
-    bbox = font.getbbox(label)
-    tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
     padding = 8
     lx = padding
-    ly = img.height - th - padding
+    ly = padding
 
     # White outline for readability on any background
     for dx in (-1, 0, 1):
@@ -277,6 +293,44 @@ def _draw_frame_label(
             if dx or dy:
                 draw.text((lx + dx, ly + dy), label, fill=(255, 255, 255, 220), font=font)
     draw.text((lx, ly), label, fill=(0, 0, 0, 230), font=font)
+
+
+def _draw_attribution(img: Image.Image, style_def: MapStyleDefinition) -> None:
+    """Draw the map provider + RainViewer attribution along the full bottom of the composite.
+
+    Frame label is now at top-left, so the entire bottom edge is available.
+    14pt fits ESRI's 85-char attribution (546px) comfortably in a 640px image (624px available).
+    """
+    text = f"{style_def.attribution} | RainViewer"
+    draw = ImageDraw.Draw(img)
+    try:
+        font = ImageFont.load_default(size=14)
+    except TypeError:
+        font = ImageFont.load_default()
+
+    padding = 8
+    text_bbox = font.getbbox(text)
+    text_h = text_bbox[3] - text_bbox[1]
+
+    lx = padding
+    ly = img.height - text_h - padding
+
+    _draw_text_with_outline(draw, lx, ly, text, font)
+
+
+def _draw_text_with_outline(
+    draw: ImageDraw.ImageDraw,
+    x: int,
+    y: int,
+    text: str,
+    font,
+) -> None:
+    """Draw text with a white outline and dark fill for readability on any background."""
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            if dx or dy:
+                draw.text((x + dx, y + dy), text, fill=(255, 255, 255, 220), font=font)
+    draw.text((x, y), text, fill=(0, 0, 0, 230), font=font)
 
 
 def _composite_single_frame(
@@ -291,6 +345,7 @@ def _composite_single_frame(
     tz_name: str | None = None,
     confidence_map: np.ndarray | None = None,
     location_name: str | None = None,
+    style_def: MapStyleDefinition | None = None,
 ) -> Image.Image:
     """CPU-bound rendering: composite map + radar, draw overlays. Returns RGBA Image.
 
@@ -340,6 +395,10 @@ def _composite_single_frame(
 
     _draw_frame_label(composite, timestamp, tz_name, radius_km, location_name)
 
+    if style_def is None:
+        style_def = get_style(MapStyle.VOYAGER)
+    _draw_attribution(composite, style_def)
+
     return composite
 
 
@@ -351,10 +410,12 @@ def _render_sync(
     map_zoom: int,
     radius_km: int,
     output_size: int,
+    style_def: MapStyleDefinition | None = None,
 ) -> bytes:
     """CPU-bound rendering: composite, draw overlays, export PNG."""
     composite = _composite_single_frame(
         map_crop, radar_resized, lat, lon, map_zoom, radius_km, output_size,
+        style_def=style_def,
     )
     buf = BytesIO()
     composite.save(buf, format="PNG")
@@ -440,8 +501,12 @@ async def _fetch_map_crop(
     session: aiohttp.ClientSession,
     vp: _ViewportParams,
     output_size: int,
+    style_def: MapStyleDefinition | None = None,
 ) -> Image.Image:
     """Fetch and stitch map tiles (in parallel), then crop to viewport."""
+    if style_def is None:
+        style_def = get_style(MapStyle.VOYAGER)
+
     coords = [
         (tx, ty)
         for ty in range(vp.tile_y_min, vp.tile_y_max + 1)
@@ -450,7 +515,7 @@ async def _fetch_map_crop(
 
     async def _fetch_one(tx: int, ty: int):
         try:
-            return tx, ty, await _fetch_map_tile(session, vp.map_zoom, tx, ty)
+            return tx, ty, await _fetch_map_tile(session, vp.map_zoom, tx, ty, style_def)
         except aiohttp.ClientResponseError as e:
             _LOGGER.warning(
                 "Map tile fetch failed: HTTP %d for z=%d x=%d y=%d",
@@ -576,6 +641,7 @@ async def render_composite(
     *,
     session: aiohttp.ClientSession,
     run_in_executor: object = None,
+    map_style: MapStyle | str = MapStyle.VOYAGER,
 ) -> bytes:
     """Render a radar composite image as PNG bytes.
 
@@ -584,17 +650,20 @@ async def render_composite(
     session: an aiohttp.ClientSession for fetching tiles.
     run_in_executor: optional callable (e.g. hass.async_add_executor_job)
         to offload CPU-bound rendering. If None, rendering runs inline.
+    map_style: base map provider. Defaults to VOYAGER.
     """
+    style_def = get_style(map_style)
     vp = _ViewportParams(lat, lon, radius_km, output_size)
-    map_crop = await _fetch_map_crop(session, vp, output_size)
+    map_crop = await _fetch_map_crop(session, vp, output_size, style_def)
     radar_resized = await _fetch_radar_overlay(session, vp, frame_path, output_size)
 
     if run_in_executor is not None:
         return await run_in_executor(
             _render_sync, map_crop, radar_resized, lat, lon, vp.map_zoom, radius_km, output_size,
+            style_def,
         )
 
-    return _render_sync(map_crop, radar_resized, lat, lon, vp.map_zoom, radius_km, output_size)
+    return _render_sync(map_crop, radar_resized, lat, lon, vp.map_zoom, radius_km, output_size, style_def)
 
 
 # --- Public composable API ---
@@ -609,10 +678,17 @@ async def fetch_map_crop(
     lon: float,
     radius_km: int,
     output_size: int = 640,
+    map_style: MapStyle | str = MapStyle.VOYAGER,
 ) -> Image.Image:
-    """Fetch CartoDB map tiles for a location and radius. Returns a cropped PIL image."""
+    """Fetch map tiles for a location and radius. Returns a cropped PIL image.
+
+    map_style selects the base map provider. Defaults to VOYAGER (CARTO) to
+    preserve existing production behaviour. Pass any MapStyle value or its
+    string equivalent (e.g. "osm_dark") to change the map style.
+    """
+    style_def = get_style(map_style)
     vp = _ViewportParams(lat, lon, radius_km, output_size)
-    return await _fetch_map_crop(session, vp, output_size)
+    return await _fetch_map_crop(session, vp, output_size, style_def)
 
 
 async def fetch_radar_overlays(
@@ -642,8 +718,10 @@ def composite_frames(
     tz_name: str | None = None,
     confidence_maps: list[np.ndarray] | None = None,
     location_name: str | None = None,
+    map_style: MapStyle | str = MapStyle.VOYAGER,
 ) -> list[Image.Image]:
     """Composite radar overlays over a background image. Returns a list of frames."""
+    style_def = get_style(map_style)
     vp = _ViewportParams(lat, lon, radius_km, output_size)
     timestamps = frame_timestamps or [None] * len(radar_overlays)
     frames: list[Image.Image] = []
@@ -655,6 +733,7 @@ def composite_frames(
             timestamp=ts, tz_name=tz_name,
             confidence_map=conf_map,
             location_name=location_name,
+            style_def=style_def,
         )
         frames.append(frame_img)
     return frames
@@ -690,6 +769,7 @@ async def render_animated_composite(
     location_name: str | None = None,
     session: aiohttp.ClientSession,
     run_in_executor: object = None,
+    map_style: MapStyle | str = MapStyle.VOYAGER,
 ) -> bytes:
     """Render an animated GIF compositing multiple radar frames over a static map.
 
@@ -699,7 +779,7 @@ async def render_animated_composite(
     import time as _time
     t0 = _time.monotonic()
 
-    map_crop = await fetch_map_crop(session, lat, lon, radius_km, output_size)
+    map_crop = await fetch_map_crop(session, lat, lon, radius_km, output_size, map_style)
     t1 = _time.monotonic()
     _LOGGER.debug("render %dkm: map tiles fetched in %.1fs", radius_km, t1 - t0)
 
@@ -718,6 +798,7 @@ async def render_animated_composite(
         tz_name=tz_name,
         confidence_maps=confidence_maps,
         location_name=location_name,
+        map_style=map_style,
     )
     t3 = _time.monotonic()
     _LOGGER.debug("render %dkm: %d frames composited in %.1fs", radius_km, len(frames), t3 - t2)

--- a/custom_components/rain_incoming/radar/map_styles.py
+++ b/custom_components/rain_incoming/radar/map_styles.py
@@ -17,6 +17,8 @@ import aiohttp
 import numpy as np
 from PIL import Image, ImageEnhance
 
+from ..http_retry import fetch_with_retry
+
 _LOGGER = logging.getLogger(__name__)
 
 # Saturation multiplier applied to OSM tiles before the HSV V-invert + feature lift.
@@ -55,18 +57,20 @@ class MapStyleDefinition:
 async def _fetch_png(session: aiohttp.ClientSession, url: str) -> Image.Image | None:
     """Fetch a PNG tile URL and return it as an RGBA PIL Image, or None on failure.
 
-    Failures (non-200 status, network errors) are logged at WARNING level and
-    None is returned so the caller can decide whether to fail or fall back.
+    Uses fetch_with_retry for 429/5xx retry with exponential backoff.
+    404 errors are silently returned as None (expected for ESRI overlay tiles at
+    some zoom levels). Other 4xx errors are logged at WARNING and return None.
+    Network/timeout errors are also logged at WARNING and return None.
     """
     try:
-        async with session.get(url, headers={"User-Agent": _USER_AGENT}) as resp:
-            if resp.status != 200:
-                _LOGGER.warning(
-                    "Map tile fetch failed: HTTP %d for %s", resp.status, url
-                )
-                return None
-            data = await resp.read()
-            return Image.open(BytesIO(data)).convert("RGBA")
+        resp = await fetch_with_retry(session, url)
+        data = await resp.read()
+        return Image.open(BytesIO(data)).convert("RGBA")
+    except aiohttp.ClientResponseError as exc:
+        if exc.status == 404:
+            return None  # overlay tile doesn't exist at this zoom - expected, don't warn
+        _LOGGER.warning("Map tile fetch failed: HTTP %d for %s", exc.status, url)
+        return None
     except Exception as exc:
         _LOGGER.warning(
             "Map tile fetch error: %s: %s for %s", type(exc).__name__, exc, url

--- a/custom_components/rain_incoming/strings.json
+++ b/custom_components/rain_incoming/strings.json
@@ -8,14 +8,17 @@
           "latitude": "Latitude",
           "longitude": "Longitude",
           "lookahead_minutes": "Lookahead (minutes)",
-          "location_name": "Location name (optional)"
+          "location_name": "Location name (optional)",
+          "map_style": "Map style"
         }
       }
     },
     "error": {
       "invalid_latitude": "Latitude must be between -90 and 90",
       "invalid_longitude": "Longitude must be between -180 and 180",
-      "invalid_lookahead": "Lookahead must be between 20 and 60 minutes"
+      "invalid_lookahead": "Lookahead must be between 20 and 60 minutes",
+      "location_name_too_long": "Location name must be 30 characters or fewer (avoids overlap with map attribution on the bottom of the composite).",
+      "invalid_map_style": "Please select a valid map style"
     },
     "abort": {
       "already_configured": "This location is already configured"
@@ -26,17 +29,16 @@
       "init": {
         "title": "Configure Rain Incoming",
         "data": {
-          "latitude": "Latitude",
-          "longitude": "Longitude",
           "lookahead_minutes": "Lookahead (minutes)",
-          "location_name": "Location name (optional)"
+          "location_name": "Location name (optional)",
+          "map_style": "Map style"
         }
       }
     },
     "error": {
-      "invalid_latitude": "Latitude must be between -90 and 90",
-      "invalid_longitude": "Longitude must be between -180 and 180",
-      "invalid_lookahead": "Lookahead must be between 20 and 60 minutes"
+      "invalid_lookahead": "Lookahead must be between 20 and 60 minutes",
+      "location_name_too_long": "Location name must be 30 characters or fewer (avoids overlap with map attribution on the bottom of the composite).",
+      "invalid_map_style": "Please select a valid map style"
     }
   }
 }

--- a/custom_components/rain_incoming/translations/en.json
+++ b/custom_components/rain_incoming/translations/en.json
@@ -8,14 +8,17 @@
           "latitude": "Latitude",
           "longitude": "Longitude",
           "lookahead_minutes": "Lookahead (minutes)",
-          "location_name": "Location name (optional)"
+          "location_name": "Location name (optional)",
+          "map_style": "Map style"
         }
       }
     },
     "error": {
       "invalid_latitude": "Latitude must be between -90 and 90",
       "invalid_longitude": "Longitude must be between -180 and 180",
-      "invalid_lookahead": "Lookahead must be between 20 and 60 minutes"
+      "invalid_lookahead": "Lookahead must be between 20 and 60 minutes",
+      "location_name_too_long": "Location name must be 30 characters or fewer (avoids overlap with map attribution on the bottom of the composite).",
+      "invalid_map_style": "Please select a valid map style"
     },
     "abort": {
       "already_configured": "This location is already configured"
@@ -26,17 +29,16 @@
       "init": {
         "title": "Configure Rain Incoming",
         "data": {
-          "latitude": "Latitude",
-          "longitude": "Longitude",
           "lookahead_minutes": "Lookahead (minutes)",
-          "location_name": "Location name (optional)"
+          "location_name": "Location name (optional)",
+          "map_style": "Map style"
         }
       }
     },
     "error": {
-      "invalid_latitude": "Latitude must be between -90 and 90",
-      "invalid_longitude": "Longitude must be between -180 and 180",
-      "invalid_lookahead": "Lookahead must be between 20 and 60 minutes"
+      "invalid_lookahead": "Lookahead must be between 20 and 60 minutes",
+      "location_name_too_long": "Location name must be 30 characters or fewer (avoids overlap with map attribution on the bottom of the composite).",
+      "invalid_map_style": "Please select a valid map style"
     }
   }
 }

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -3,8 +3,27 @@ from __future__ import annotations
 import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers.selector import SelectSelector
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+from unittest.mock import patch
 
-from custom_components.rain_incoming.const import DOMAIN
+from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
+
+from custom_components.rain_incoming.const import (
+    CONF_LOCATION_NAME,
+    CONF_MAP_STYLE,
+    DOMAIN,
+)
+from .conftest import setup_integration
+from custom_components.rain_incoming.radar.detector import Confidence, DetectionResult
+
+_MOCK_RESULT = DetectionResult(
+    rain_incoming=False,
+    arrival_time=None,
+    confidence=Confidence.UNAVAILABLE,
+    frame_count=0,
+    max_approaching_intensity=0.0,
+)
 
 
 @pytest.mark.asyncio
@@ -122,3 +141,435 @@ async def test_config_flow_rejects_lookahead_out_of_range(hass: HomeAssistant):
     )
     assert result["type"] == FlowResultType.FORM
     assert "lookahead_minutes" in result["errors"]
+
+
+# ---------------------------------------------------------------------------
+# PR 3: map_style field + location_name validator + options flow + migration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_config_flow_rejects_location_name_over_30_chars(hass: HomeAssistant):
+    """RED: location_name > 30 chars should be rejected with a validation error."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            "location_name": "A" * 40,  # 40 chars - over the 30-char limit
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert "location_name" in result["errors"]
+
+
+@pytest.mark.asyncio
+async def test_config_flow_stores_map_style_in_entry(hass: HomeAssistant):
+    """RED: map_style should be stored in entry.data when submitted."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            "map_style": "osm_dark",
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_MAP_STYLE] == "osm_dark"
+
+
+@pytest.mark.asyncio
+async def test_config_flow_defaults_map_style_to_voyager(hass: HomeAssistant):
+    """Submitting without map_style should default to 'voyager'."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"].get(CONF_MAP_STYLE) == "voyager"
+
+
+@pytest.mark.asyncio
+async def test_config_flow_rejects_invalid_map_style(hass: HomeAssistant):
+    """Submitting an unrecognised map_style string should be rejected.
+
+    With SelectSelector, HA validates the value against the allowed list at the
+    schema level and raises InvalidData before the flow returns a form with errors.
+    """
+    from homeassistant.data_entry_flow import InvalidData
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    with pytest.raises(InvalidData):
+        await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {
+                "latitude": -33.701,
+                "longitude": 151.209,
+                "lookahead_minutes": 60,
+                "map_style": "not_a_real_style",
+            },
+        )
+
+
+@pytest.mark.asyncio
+async def test_options_flow_changes_map_style(hass: HomeAssistant):
+    """Options flow should persist a new map_style to entry.options."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "voyager",
+        },
+        version=2,
+    )
+    await setup_integration(hass, entry, _MOCK_RESULT)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "location_name": "Beach House",
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "esri_imagery",
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.options[CONF_MAP_STYLE] == "esri_imagery"
+
+
+@pytest.mark.asyncio
+async def test_options_flow_rejects_location_name_over_30_chars(hass: HomeAssistant):
+    """Options flow should reject location_name > 30 chars."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "voyager",
+        },
+        version=2,
+    )
+    await setup_integration(hass, entry, _MOCK_RESULT)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "location_name": "B" * 40,
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "voyager",
+        },
+    )
+    assert result["type"] == FlowResultType.FORM
+    assert "location_name" in result["errors"]
+
+
+# ---------------------------------------------------------------------------
+# Migration tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_migration_adds_map_style_to_v1_entry(hass: HomeAssistant):
+    """RED: a v1 entry without map_style should be migrated to v2 with map_style=voyager."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+        },
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    # Loading the integration should trigger async_migrate_entry and bump the version.
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # After migration, the entry should be on version 2 with map_style set.
+    assert entry.version == 2
+    assert entry.data.get(CONF_MAP_STYLE) == "voyager"
+
+
+@pytest.mark.asyncio
+async def test_migration_preserves_long_location_name(hass: HomeAssistant):
+    """v1 entry with location_name > 30 chars should migrate without rejection."""
+    long_name = "A" * 50
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            "location_name": long_name,
+        },
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # Migration should succeed - render-time truncation handles display.
+    assert entry.version == 2
+    assert entry.data.get(CONF_MAP_STYLE) == "voyager"
+    assert entry.data["location_name"] == long_name  # preserved, not truncated
+
+
+@pytest.mark.asyncio
+async def test_migration_does_not_re_migrate_v2_entry(hass: HomeAssistant):
+    """A v2 entry should not be migrated a second time."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "osm_dark",
+        },
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    await hass.config_entries.async_setup(entry.entry_id)
+    await hass.async_block_till_done()
+
+    # map_style should remain unchanged at the value set at v2 creation.
+    assert entry.version == 2
+    assert entry.data[CONF_MAP_STYLE] == "osm_dark"
+
+
+# ---------------------------------------------------------------------------
+# Coordinator wiring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_coordinator_uses_options_map_style_over_data(hass: HomeAssistant):
+    """Coordinator should prefer entry.options[CONF_MAP_STYLE] over entry.data."""
+    from custom_components.rain_incoming.coordinator import RainDetectorCoordinator
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "voyager",
+        },
+        options={CONF_MAP_STYLE: "esri_imagery"},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = RainDetectorCoordinator(hass, entry)
+    assert coordinator.map_style == "esri_imagery"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_falls_back_to_data_map_style(hass: HomeAssistant):
+    """Coordinator uses entry.data[CONF_MAP_STYLE] when options doesn't have it."""
+    from custom_components.rain_incoming.coordinator import RainDetectorCoordinator
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "osm_standard",
+        },
+        options={},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = RainDetectorCoordinator(hass, entry)
+    assert coordinator.map_style == "osm_standard"
+
+
+@pytest.mark.asyncio
+async def test_coordinator_defaults_to_voyager_when_no_style_set(hass: HomeAssistant):
+    """Coordinator defaults to voyager when neither options nor data has map_style."""
+    from custom_components.rain_incoming.coordinator import RainDetectorCoordinator
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+        },
+        options={},
+        version=2,
+    )
+    entry.add_to_hass(hass)
+
+    coordinator = RainDetectorCoordinator(hass, entry)
+    assert coordinator.map_style == "voyager"
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: SelectSelector for map_style dropdown
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_map_style_field_uses_select_selector_in_config_flow(hass: HomeAssistant):
+    """CONF_MAP_STYLE in config flow schema must use SelectSelector for dropdown UI."""
+    from custom_components.rain_incoming.config_flow import _build_schema
+
+    schema = _build_schema(
+        default_lat=-33.701,
+        default_lon=151.209,
+    )
+    for key in schema.schema:
+        if getattr(key, "schema", None) == CONF_MAP_STYLE:
+            assert isinstance(schema.schema[key], SelectSelector), (
+                f"CONF_MAP_STYLE should use SelectSelector for dropdown UI, "
+                f"got {type(schema.schema[key]).__name__}"
+            )
+            return
+    pytest.fail("CONF_MAP_STYLE not found in config flow schema")
+
+
+@pytest.mark.asyncio
+async def test_map_style_field_uses_select_selector_in_options_flow(hass: HomeAssistant):
+    """CONF_MAP_STYLE in options flow schema must use SelectSelector for dropdown UI."""
+    from custom_components.rain_incoming.config_flow import _build_options_schema
+
+    schema = _build_options_schema()
+    for key in schema.schema:
+        if getattr(key, "schema", None) == CONF_MAP_STYLE:
+            assert isinstance(schema.schema[key], SelectSelector), (
+                f"CONF_MAP_STYLE should use SelectSelector for dropdown UI, "
+                f"got {type(schema.schema[key]).__name__}"
+            )
+            return
+    pytest.fail("CONF_MAP_STYLE not found in options flow schema")
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: async_schedule_reload assertion in options flow test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_options_flow_schedules_reload_after_save(hass: HomeAssistant):
+    """Options flow must call async_schedule_reload after saving so changes take effect."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "voyager",
+        },
+        version=2,
+    )
+    await setup_integration(hass, entry, _MOCK_RESULT)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+
+    with patch.object(
+        hass.config_entries, "async_schedule_reload"
+    ) as mock_reload:
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {
+                "location_name": "Beach House",
+                "lookahead_minutes": 60,
+                CONF_MAP_STYLE: "esri_imagery",
+            },
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    mock_reload.assert_called_once_with(entry.entry_id)
+
+
+# ---------------------------------------------------------------------------
+# Fix 3: boundary test for 30-char location name
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_config_flow_accepts_location_name_exactly_30_chars(hass: HomeAssistant):
+    """Location name of exactly 30 chars must be accepted (boundary at limit)."""
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"],
+        {
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            "location_name": "A" * 30,  # exactly at the 30-char limit
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_LOCATION_NAME] == "A" * 30
+
+
+# ---------------------------------------------------------------------------
+# Fix 4: lat/lon immutability via options flow
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_options_flow_does_not_modify_latitude_longitude(hass: HomeAssistant):
+    """Lat/lon in entry.data must be unchanged after an options flow save."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "voyager",
+        },
+        version=2,
+    )
+    await setup_integration(hass, entry, _MOCK_RESULT)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+
+    # Submit with only the fields the options flow knows about (no lat/lon).
+    # Lat/lon are not in the options schema so they cannot be submitted.
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            CONF_MAP_STYLE: "esri_imagery",
+            "location_name": "Updated Name",
+            "lookahead_minutes": 60,
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+
+    # Verify latitude/longitude in entry.data are unchanged.
+    assert entry.data[CONF_LATITUDE] == -33.701
+    assert entry.data[CONF_LONGITUDE] == 151.209

--- a/tests/unit/radar/test_attribution.py
+++ b/tests/unit/radar/test_attribution.py
@@ -1,0 +1,298 @@
+"""Tests for _draw_attribution in composite.py.
+
+TDD: written FIRST (red), then implementation makes them green.
+
+Requirements:
+- Attribution text "{style.attribution} | RainViewer" appears on each frame
+- Positioned along the bottom of the image (full width available - frame label is now at top)
+- Single-line for all styles including ESRI's 85-char attribution at the chosen font size
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from PIL import Image, ImageFont
+
+from custom_components.rain_incoming.radar.composite import _draw_attribution
+from custom_components.rain_incoming.radar.map_styles import MapStyle, get_style
+
+
+def _blank_image(width=640, height=640) -> Image.Image:
+    """Create a blank black RGBA image."""
+    return Image.new("RGBA", (width, height), (0, 0, 0, 255))
+
+
+def _bottom_region(img: Image.Image, height_fraction: float = 0.05) -> np.ndarray:
+    """Return the bottom strip of the image as a numpy array (RGB only)."""
+    arr = np.array(img)
+    h, w = arr.shape[:2]
+    region_h = max(1, int(h * height_fraction))
+    # Bottom slice, full width, RGB only (ignore alpha channel which is always 255)
+    return arr[h - region_h:h, :, :3]
+
+
+def _count_nonblack_pixels(region: np.ndarray) -> int:
+    """Count pixels with any RGB channel > 10."""
+    return int((region.max(axis=2) > 10).sum())
+
+
+# ---------------------------------------------------------------------------
+# Attribution text appears in the bottom region
+# ---------------------------------------------------------------------------
+
+def test_draw_attribution_renders_style_text():
+    """_draw_attribution should draw text in the bottom region of the image.
+
+    A blank black image should have non-black pixels in the bottom strip after
+    calling _draw_attribution - proving text was rendered there.
+    """
+    img = _blank_image()
+    style_def = get_style(MapStyle.VOYAGER)
+    _draw_attribution(img, style_def)
+
+    region = _bottom_region(img)
+    nonblack = _count_nonblack_pixels(region)
+    assert nonblack > 0, (
+        "Expected non-black pixels in bottom region after _draw_attribution, "
+        "but the region is still all-black. Attribution was not drawn."
+    )
+
+
+def test_draw_attribution_includes_rainviewer():
+    """The drawn attribution must include 'RainViewer' - verified by rendering non-empty text."""
+    # We can't easily OCR the image in tests, but we verify _draw_attribution draws
+    # something for every style. The 'RainViewer' content is verified at the string level
+    # via the implementation contract: the text must be f"{style_def.attribution} | RainViewer".
+    for style in MapStyle:
+        img = _blank_image()
+        style_def = get_style(style)
+        _draw_attribution(img, style_def)
+        region = _bottom_region(img)
+        nonblack = _count_nonblack_pixels(region)
+        assert nonblack > 0, (
+            f"Expected attribution text for style={style} in bottom region, "
+            f"but region is all-black. Text may have been placed elsewhere or not drawn."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Regression test: ESRI's long attribution must fit on one line at chosen font size
+# ---------------------------------------------------------------------------
+
+def test_draw_attribution_esri_fits_single_line():
+    """ESRI's 85-char attribution must fit within img.width - 2*padding at the chosen font size.
+
+    This is a regression guard: if someone bumps the font size up beyond what fits,
+    this test will catch it. The implementation uses 14pt which gives 546px for ESRI
+    on a 640px image (624px available after padding).
+    """
+    from custom_components.rain_incoming.radar.map_styles import MapStyle, get_style
+
+    padding = 8
+    img_width = 640
+    available_width = img_width - 2 * padding
+
+    # Match the font size used in _draw_attribution
+    try:
+        font = ImageFont.load_default(size=14)
+    except TypeError:
+        font = ImageFont.load_default()
+
+    esri_def = get_style(MapStyle.ESRI_IMAGERY)
+    text = f"{esri_def.attribution} | RainViewer"
+    bbox = font.getbbox(text)
+    text_w = bbox[2] - bbox[0]
+
+    assert text_w < available_width, (
+        f"ESRI attribution text is {text_w}px wide but only {available_width}px available "
+        f"({img_width}px image - {2*padding}px padding). Reduce font size in _draw_attribution "
+        f"to fit ESRI on a single line. Text: {text!r}"
+    )
+
+
+def test_draw_attribution_frame_label_position_is_top():
+    """_draw_frame_label should place text in the top region of the image, not the bottom.
+
+    After calling _draw_frame_label, the top strip should have non-black pixels
+    and the very bottom strip should remain black (no text overlap between label and attribution).
+    This verifies the layout separation: label at top, attribution at bottom.
+    """
+    from custom_components.rain_incoming.radar.composite import _draw_frame_label
+    from datetime import datetime, timezone
+
+    img = _blank_image()
+    ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+    _draw_frame_label(img, ts, "UTC", 128, "Sydney")
+
+    arr = np.array(img)[:, :, :3]
+    h = arr.shape[0]
+
+    # Top strip should have text pixels
+    top_strip = arr[:int(h * 0.05), :, :]
+    top_nonblack = int((top_strip.max(axis=2) > 10).sum())
+
+    # Bottom strip (bottom 5%) should be empty (no text rendered there)
+    bottom_strip = arr[int(h * 0.95):, :, :]
+    bottom_nonblack = int((bottom_strip.max(axis=2) > 10).sum())
+
+    assert top_nonblack > 0, (
+        "Expected frame label text pixels in the top strip of the image, "
+        "but the top strip is all-black. Label may still be at the bottom."
+    )
+    assert bottom_nonblack == 0, (
+        f"Expected no frame label pixels in the bottom strip, "
+        f"but found {bottom_nonblack} non-black pixels. Label may still be at the bottom."
+    )
+
+
+# ---------------------------------------------------------------------------
+# P0 regression: render_composite must pass style_def through _render_sync
+# ---------------------------------------------------------------------------
+
+def test_render_composite_uses_passed_style_for_attribution():
+    """render_composite called with ESRI_IMAGERY must draw ESRI's attribution, not Voyager's.
+
+    The bug: render_composite computed style_def but did not pass it through
+    _render_sync -> _composite_single_frame, so _composite_single_frame always
+    fell back to VOYAGER's attribution regardless of what style was requested.
+
+    This test mocks _draw_attribution so we can inspect exactly which style_def
+    was used - pixel-level verification is covered by test_draw_attribution_renders_style_text.
+    """
+    from unittest.mock import patch, MagicMock, AsyncMock
+    import asyncio
+    from io import BytesIO
+    from PIL import Image
+
+    from custom_components.rain_incoming.radar.composite import render_composite, _map_tile_cache
+    from custom_components.rain_incoming.radar.map_styles import MapStyle, get_style
+
+    # Build a minimal mock session that returns valid PNG tiles
+    tile_png = BytesIO()
+    Image.new("RGBA", (256, 256), (80, 80, 80, 255)).save(tile_png, format="PNG")
+    tile_bytes = tile_png.getvalue()
+
+    async def _fake_get(url: str, **kwargs):
+        resp = MagicMock()
+        resp.status = 200
+        resp.headers = {}
+        resp.raise_for_status = MagicMock()
+        resp.release = MagicMock()
+        resp.read = AsyncMock(return_value=tile_bytes)
+        return resp
+
+    session = MagicMock()
+    session.get = AsyncMock(side_effect=_fake_get)
+
+    called_with_style: list = []
+
+    # Import the real function BEFORE patching so we can call it without recursion
+    from custom_components.rain_incoming.radar.composite import _draw_attribution as _real_draw
+
+    def _capture_draw_attribution(img, style_def):
+        called_with_style.append(style_def)
+        # Still draw so rendering doesn't error - call the real function directly
+        _real_draw(img, style_def)
+
+    _map_tile_cache.clear()
+
+    with patch(
+        "custom_components.rain_incoming.radar.composite._draw_attribution",
+        side_effect=_capture_draw_attribution,
+    ):
+        asyncio.get_event_loop().run_until_complete(
+            render_composite(
+                lat=-33.7,
+                lon=151.2,
+                radius_km=128,
+                frame_path="/test/radar/frame",
+                output_size=256,
+                session=session,
+                map_style=MapStyle.ESRI_IMAGERY,
+            )
+        )
+
+    assert called_with_style, "_draw_attribution was never called"
+    used_style_def = called_with_style[0]
+    esri_def = get_style(MapStyle.ESRI_IMAGERY)
+    assert used_style_def.style == MapStyle.ESRI_IMAGERY, (
+        f"render_composite with map_style=ESRI_IMAGERY should draw ESRI attribution, "
+        f"but _draw_attribution was called with style={used_style_def.style!r}. "
+        f"Expected {MapStyle.ESRI_IMAGERY!r}. "
+        f"This is the P0 bug: style_def was not threaded through _render_sync."
+    )
+    assert "Esri" in used_style_def.attribution, (
+        f"ESRI style_def attribution should mention 'Esri', got: {used_style_def.attribution!r}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Layout integrity: label at top, attribution at bottom - no leakage
+# ---------------------------------------------------------------------------
+
+def test_composite_single_frame_has_label_at_top_and_attribution_at_bottom():
+    """_composite_single_frame must place the frame label at the top and attribution at the bottom.
+
+    Layout invariant: if someone accidentally changes a vertical offset, this catches it.
+    - Top 5% of the image must have non-black pixels (frame label).
+    - Bottom 5% must have non-black pixels (attribution text).
+    - The middle 90% should NOT have label text rendered there.
+
+    Uses a blank background and ESRI style so we exercise the full code path.
+    """
+    from datetime import datetime, timezone
+    from custom_components.rain_incoming.radar.composite import _composite_single_frame
+    from custom_components.rain_incoming.radar.map_styles import MapStyle, get_style
+
+    output_size = 640
+    background = Image.new("RGBA", (output_size, output_size), (60, 60, 60, 255))
+    radar = Image.new("RGBA", (output_size, output_size), (0, 0, 0, 0))
+    ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+    esri_def = get_style(MapStyle.ESRI_IMAGERY)
+
+    result = _composite_single_frame(
+        map_crop=background,
+        radar_resized=radar,
+        lat=-33.7,
+        lon=151.2,
+        map_zoom=8,
+        radius_km=128,
+        output_size=output_size,
+        timestamp=ts,
+        tz_name="UTC",
+        location_name="Sydney",
+        style_def=esri_def,
+    )
+
+    arr = np.array(result)[:, :, :3]
+    h = arr.shape[0]
+    strip_h = int(h * 0.05)
+
+    # The background is grey (60, 60, 60) - "non-black" includes that.
+    # We compare against what the background alone would look like: max(axis=2) = 60.
+    # Text pixels are white (255) or black (0) outlines against that grey background.
+    # We detect text by looking for pixels that DIFFER significantly from the grey background.
+    _BACKGROUND_GREY = 60
+    _TEXT_DELTA_THRESHOLD = 30  # pixels that differ from background grey by this much are text
+
+    def _count_text_pixels(strip: np.ndarray) -> int:
+        """Count pixels that differ from the background grey significantly."""
+        delta = np.abs(strip.astype(np.int32) - _BACKGROUND_GREY).max(axis=2)
+        return int((delta > _TEXT_DELTA_THRESHOLD).sum())
+
+    top_strip = arr[:strip_h, :, :]
+    bottom_strip = arr[h - strip_h:, :, :]
+    # Middle excludes top + bottom strips
+    middle_strip = arr[strip_h * 2:h - strip_h * 2, :, :]
+
+    top_text = _count_text_pixels(top_strip)
+    bottom_text = _count_text_pixels(bottom_strip)
+
+    assert top_text > 0, (
+        f"Expected frame label pixels in the top {strip_h}px strip, "
+        f"but found {top_text} text pixels. Frame label may not be at the top."
+    )
+    assert bottom_text > 0, (
+        f"Expected attribution pixels in the bottom {strip_h}px strip, "
+        f"but found {bottom_text} text pixels. Attribution may not be at the bottom."
+    )

--- a/tests/unit/radar/test_composite_map_styles.py
+++ b/tests/unit/radar/test_composite_map_styles.py
@@ -1,0 +1,183 @@
+"""Tests for map_style integration in composite.py.
+
+TDD: written FIRST (red), then implementation makes them green.
+
+Covers:
+- fetch_map_crop defaults to VOYAGER style
+- fetch_map_crop passes the style parameter through to the correct fetch_tile
+- build_frame_label truncates location names > 30 chars
+- build_frame_label leaves names <= 30 chars untouched
+"""
+from __future__ import annotations
+
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from PIL import Image
+
+from custom_components.rain_incoming.radar.composite import (
+    build_frame_label,
+    fetch_map_crop,
+)
+from custom_components.rain_incoming.radar.map_styles import MapStyle
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tile_png(colour=(128, 128, 128, 255)) -> bytes:
+    img = Image.new("RGBA", (256, 256), colour)
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+# ---------------------------------------------------------------------------
+# Style parameter tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fetch_map_crop_default_style_is_voyager():
+    """Calling fetch_map_crop without a style arg must use the Voyager tile URL.
+
+    We inspect the URLs passed to session.get and verify the Voyager CartoDB
+    URL pattern appears. This proves the default routes to VOYAGER without
+    needing to patch into the frozen MapStyleDefinition dataclass.
+    """
+    from custom_components.rain_incoming.radar.composite import _map_tile_cache
+
+    tile_bytes = _make_tile_png()
+    fetched_urls: list[str] = []
+
+    async def _fake_get(url: str, **kwargs):
+        fetched_urls.append(url)
+        resp = MagicMock()
+        resp.status = 200
+        resp.headers = {}
+        resp.raise_for_status = MagicMock()
+        resp.release = MagicMock()
+        resp.read = AsyncMock(return_value=tile_bytes)
+        return resp
+
+    session = MagicMock()
+    session.get = AsyncMock(side_effect=_fake_get)
+
+    _map_tile_cache.clear()
+    await fetch_map_crop(
+        session=session, lat=-33.7, lon=151.2, radius_km=128,
+        # No map_style argument - should default to VOYAGER
+    )
+
+    voyager_urls = [u for u in fetched_urls if "basemaps.cartocdn.com/rastertiles/voyager" in u]
+    assert voyager_urls, (
+        f"Expected at least one CartoDB Voyager URL in fetched URLs, "
+        f"but got: {fetched_urls}"
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("style, url_fragment", [
+    (MapStyle.VOYAGER, "basemaps.cartocdn.com/rastertiles/voyager"),
+    (MapStyle.OSM_STANDARD, "tile.openstreetmap.org"),
+    (MapStyle.OSM_DARK, "tile.openstreetmap.org"),
+    (MapStyle.ESRI_IMAGERY, "arcgisonline.com"),
+])
+async def test_fetch_map_crop_passes_style_through(style: MapStyle, url_fragment: str):
+    """Passing each MapStyle to fetch_map_crop should route to that style's tile server.
+
+    We inspect the URLs session.get was called with and verify the expected
+    tile server URL appears.
+    """
+    from custom_components.rain_incoming.radar.composite import _map_tile_cache
+
+    _map_tile_cache.clear()
+    tile_bytes = _make_tile_png()
+    fetched_urls: list[str] = []
+
+    async def _fake_get(url: str, **kwargs):
+        fetched_urls.append(url)
+        resp = MagicMock()
+        resp.status = 200
+        resp.headers = {}
+        resp.raise_for_status = MagicMock()
+        resp.release = MagicMock()
+        resp.read = AsyncMock(return_value=tile_bytes)
+        return resp
+
+    session = MagicMock()
+    session.get = AsyncMock(side_effect=_fake_get)
+
+    _map_tile_cache.clear()
+    await fetch_map_crop(
+        session=session, lat=-33.7, lon=151.2, radius_km=128,
+        map_style=style,
+    )
+
+    matching = [u for u in fetched_urls if url_fragment in u]
+    assert matching, (
+        f"fetch_map_crop with style={style} should fetch from {url_fragment!r}, "
+        f"but fetched URLs were: {fetched_urls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Location name truncation tests
+# ---------------------------------------------------------------------------
+
+def test_build_frame_label_truncates_long_location_names():
+    """Location names > 30 chars must be truncated to 29 chars + ellipsis."""
+    long_name = "A" * 40  # 40 chars - clearly over the limit
+    label = build_frame_label(
+        timestamp=None, tz_name=None, radius_km=128, location_name=long_name,
+    )
+    truncated = "A" * 29 + "\u2026"
+    assert truncated in label, (
+        f"Expected truncated name {truncated!r} in label, got: {label!r}"
+    )
+    assert long_name not in label, (
+        f"Full 40-char name should not appear in label, got: {label!r}"
+    )
+
+    # Boundary case: 31 chars is the FIRST length that triggers truncation.
+    # Off-by-one bugs live here (e.g. > vs >= in the length check).
+    name_31 = "D" * 31
+    label_31 = build_frame_label(
+        timestamp=None, tz_name=None, radius_km=128, location_name=name_31,
+    )
+    truncated_31 = "D" * 29 + "\u2026"
+    assert truncated_31 in label_31, (
+        f"31-char name should be truncated to 29 chars + ellipsis, got: {label_31!r}"
+    )
+    assert name_31 not in label_31, (
+        f"Full 31-char name should not appear in label, got: {label_31!r}"
+    )
+
+    # Boundary just below: 30-char name must NOT be truncated
+    name_30_boundary = "E" * 30
+    label_30 = build_frame_label(
+        timestamp=None, tz_name=None, radius_km=128, location_name=name_30_boundary,
+    )
+    assert name_30_boundary in label_30, (
+        f"30-char name (on the boundary) should NOT be truncated, got: {label_30!r}"
+    )
+
+
+def test_build_frame_label_leaves_short_names_intact():
+    """Location names <= 30 chars must not be truncated."""
+    name_30 = "B" * 30  # exactly 30 chars - on the boundary
+    label = build_frame_label(
+        timestamp=None, tz_name=None, radius_km=128, location_name=name_30,
+    )
+    assert name_30 in label, (
+        f"30-char name should appear unchanged in label, got: {label!r}"
+    )
+
+    name_29 = "C" * 29  # 29 chars - under the limit
+    label2 = build_frame_label(
+        timestamp=None, tz_name=None, radius_km=128, location_name=name_29,
+    )
+    assert name_29 in label2, (
+        f"29-char name should appear unchanged in label, got: {label2!r}"
+    )

--- a/tests/unit/radar/test_map_styles.py
+++ b/tests/unit/radar/test_map_styles.py
@@ -38,28 +38,46 @@ def _make_png_bytes(size=(256, 256), color=(100, 150, 200, 255)) -> bytes:
 
 
 class _MockResponse:
+    """Mock aiohttp response compatible with fetch_with_retry's direct-await pattern.
+
+    fetch_with_retry does `resp = await session.get(url, timeout=...)` and then
+    reads resp.status, resp.headers, resp.raise_for_status(), resp.read(), resp.release()
+    directly - NOT as a context manager.
+    """
+
     def __init__(self, status=200, body=b""):
         self.status = status
         self._body = body
+        self.headers: dict = {}
 
-    async def read(self):
+    async def read(self) -> bytes:
         return self._body
 
-    async def __aenter__(self):
-        return self
+    def raise_for_status(self) -> None:
+        if self.status >= 400:
+            import aiohttp
+            raise aiohttp.ClientResponseError(
+                request_info=None,  # type: ignore[arg-type]
+                history=(),
+                status=self.status,
+            )
 
-    async def __aexit__(self, *args):
-        return None
+    def release(self) -> None:
+        pass
 
 
 class _TrackingSession:
-    """Minimal mock aiohttp session that records URLs fetched."""
+    """Minimal mock aiohttp session that records URLs fetched.
+
+    session.get() must be an async function returning a response directly,
+    not a context manager - to match fetch_with_retry's calling convention.
+    """
 
     def __init__(self, url_to_bytes: dict[str, bytes]) -> None:
         self._url_to_bytes = url_to_bytes
         self.calls: list[str] = []
 
-    def get(self, url: str, **kwargs):
+    async def get(self, url: str, **kwargs):
         self.calls.append(url)
         if url in self._url_to_bytes:
             return _MockResponse(status=200, body=self._url_to_bytes[url])


### PR DESCRIPTION
## Summary
**Recovery PR**. PRs #30 (composite integration) and #31 (config flow + migration) were merged on GitHub but never reached \`main\`. This PR cherry-picks their content commits onto current main so the work actually lands.

## What happened
PRs #29, #30, #31 were a branch chain (each PR's base was the previous PR's branch, because PR #29 hadn't merged yet at the time of raising):
- #29: \`feat/map-styles-module\` → \`main\`
- #30: \`feat/map-style-integration\` → **\`feat/map-styles-module\`** (parent branch, not main)
- #31: \`feat/map-style-config-flow\` → **\`feat/map-style-integration\`** (parent branch, not main)

When PR #29 merged into main, GitHub did NOT auto-retarget #30 and #31 to main. They were merged into their original parent branches (now orphaned by #29's main merge), so their merge commits never propagated to \`main\`.

GitHub's PR list shows them as "merged" — and they were, just into the wrong base. The actual code on \`main\` is missing everything from #30 and #31.

I noticed when investigating why a fresh dev agent on a Dark Matter branch from main couldn't find the \`_VALID_MAP_STYLES\` constant that PR #31 was supposed to add.

## What's recovered
- **PR #30 (\`c7d8427\` after rebase)**: composite.py refactor to use map_styles, attribution rendering bottom-left, frame label moved to top-left, render-time location truncation, fetch_with_retry wrap. 5 files / 628 insertions / 44 deletions.
- **PR #31 (\`bcb3b0b\` after rebase)**: map_style config flow field with SelectSelector, options flow, async_migrate_entry, location_name validator, coordinator wiring, full test suite. 8 files / 638 insertions / 35 deletions.

Both commits were already test-expert approved during their original review cycles. Cherry-picked cleanly with zero conflicts (both branches were fundamentally based on the post-#29 main state).

## What's NOT in this PR
- No new code beyond what was in #30 and #31's original review-approved state
- No re-review needed — this is a re-application of already-approved work
- The original PRs should be closed without merging since their merge commits live in dead branches

## Verification
- [x] Cherry-picks applied cleanly with no conflicts
- [x] Both commits signed off via \`git rebase --signoff\`
- [x] **352 tests pass** (the same number that passed on the original PR #31 branch — full feature parity)
- [x] Hardened pre-push hook all 3 gates green

## Action items after merge
1. Close PRs #30 and #31 with a comment pointing to this recovery PR
2. Delete the orphan branches \`feat/map-style-integration\` and \`feat/map-style-config-flow\` from origin
3. The dev instance you have running with the new map styles will continue working — its config entries are already at version 2 with map_style fields populated

## Lesson for future branch chains
When using PR chains (PR B based on PR A), after PR A merges, GitHub does NOT auto-retarget child PRs to main. The maintainer must manually retarget child PRs in the GitHub UI before merging them, or the merges go into orphan parent branches and never reach main. Adding to my memory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>