### PR TITLE
feat: split header into three sections + frame counter

### DIFF
--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -274,9 +274,16 @@ def _draw_frame_label(
     tz_name: str | None,
     radius_km: int,
     location_name: str | None = None,
+    *,
+    frame_index: int | None = None,
+    frame_count: int | None = None,
 ) -> None:
-    """Draw the BOM-style label in the top-left corner of a frame."""
-    label = build_frame_label(timestamp, tz_name, radius_km, location_name)
+    """Draw header labels across the top of a frame in three positions.
+
+    - Top-left: location name (e.g. "Sydney")
+    - Top-centre: date/time (e.g. "10/04/26  20:40 UTC"), anchor='mt'
+    - Top-right: range + frame counter (e.g. "128km  3/13"), anchor='rt'
+    """
     draw = ImageDraw.Draw(img)
     try:
         font = ImageFont.load_default(size=16)
@@ -284,15 +291,27 @@ def _draw_frame_label(
         font = ImageFont.load_default()
 
     padding = 8
-    lx = padding
-    ly = padding
 
-    # White outline for readability on any background
-    for dx in (-1, 0, 1):
-        for dy in (-1, 0, 1):
-            if dx or dy:
-                draw.text((lx + dx, ly + dy), label, fill=(255, 255, 255, 220), font=font)
-    draw.text((lx, ly), label, fill=(0, 0, 0, 230), font=font)
+    # --- Top-left: location name ---
+    if location_name:
+        name = location_name
+        if len(name) > 30:
+            name = name[:29] + "\u2026"
+        _draw_text_with_outline(draw, padding, padding, name, font)
+
+    # --- Top-centre: date/time ---
+    if timestamp is not None:
+        tz_label = timestamp.strftime("%Z") or tz_name or "UTC"
+        datetime_text = f"{timestamp.strftime('%d/%m/%y')}  {timestamp.strftime(f'%H:%M {tz_label}')}"
+        cx = img.width // 2
+        _draw_text_with_outline_anchored(draw, cx, padding, datetime_text, font, anchor="mt")
+
+    # --- Top-right: range + frame counter ---
+    range_text = f"{radius_km}km"
+    if frame_index is not None and frame_count is not None:
+        range_text = f"{range_text}  {frame_index}/{frame_count}"
+    rx = img.width - padding
+    _draw_text_with_outline_anchored(draw, rx, padding, range_text, font, anchor="rt")
 
 
 def _draw_attribution(img: Image.Image, style_def: MapStyleDefinition) -> None:
@@ -334,6 +353,28 @@ def _draw_text_with_outline(
     draw.text((x, y), text, fill=(0, 0, 0, 230), font=font)
 
 
+def _draw_text_with_outline_anchored(
+    draw: ImageDraw.ImageDraw,
+    x: int,
+    y: int,
+    text: str,
+    font,
+    anchor: str = "la",
+) -> None:
+    """Draw text with a white outline using a Pillow text anchor.
+
+    anchor='mt' for top-centre, anchor='rt' for top-right, anchor='la' for top-left.
+    """
+    for dx in (-1, 0, 1):
+        for dy in (-1, 0, 1):
+            if dx or dy:
+                draw.text(
+                    (x + dx, y + dy), text,
+                    fill=(255, 255, 255, 220), font=font, anchor=anchor,
+                )
+    draw.text((x, y), text, fill=(0, 0, 0, 230), font=font, anchor=anchor)
+
+
 def _composite_single_frame(
     map_crop: Image.Image,
     radar_resized: Image.Image,
@@ -347,6 +388,8 @@ def _composite_single_frame(
     confidence_map: np.ndarray | None = None,
     location_name: str | None = None,
     style_def: MapStyleDefinition | None = None,
+    frame_index: int | None = None,
+    frame_count: int | None = None,
 ) -> Image.Image:
     """CPU-bound rendering: composite map + radar, draw overlays. Returns RGBA Image.
 
@@ -394,7 +437,10 @@ def _composite_single_frame(
     draw_range_rings(composite, cx, cy, radius_px, radius_km)
     draw_crosshair(composite, cx, cy)
 
-    _draw_frame_label(composite, timestamp, tz_name, radius_km, location_name)
+    _draw_frame_label(
+        composite, timestamp, tz_name, radius_km, location_name,
+        frame_index=frame_index, frame_count=frame_count,
+    )
 
     if style_def is None:
         style_def = get_style(MapStyle.VOYAGER)
@@ -725,6 +771,7 @@ def composite_frames(
     style_def = get_style(map_style)
     vp = _ViewportParams(lat, lon, radius_km, output_size)
     timestamps = frame_timestamps or [None] * len(radar_overlays)
+    total_frames = len(radar_overlays)
     frames: list[Image.Image] = []
     for i, radar_resized in enumerate(radar_overlays):
         ts = timestamps[i] if i < len(timestamps) else None
@@ -735,6 +782,8 @@ def composite_frames(
             confidence_map=conf_map,
             location_name=location_name,
             style_def=style_def,
+            frame_index=i + 1,
+            frame_count=total_frames,
         )
         frames.append(frame_img)
     return frames

--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -242,6 +242,13 @@ async def _fetch_map_tile(
     return tile
 
 
+def _truncate_location(name: str, max_len: int = 30) -> str:
+    """Truncate a location name to max_len chars, adding ellipsis if needed."""
+    if len(name) > max_len:
+        return name[:max_len - 1] + "\u2026"
+    return name
+
+
 def build_frame_label(
     timestamp: datetime | None,
     tz_name: str | None,
@@ -257,9 +264,7 @@ def build_frame_label(
     """
     parts = []
     if location_name:
-        if len(location_name) > 30:
-            location_name = location_name[:29] + "\u2026"
-        parts.append(location_name)
+        parts.append(_truncate_location(location_name))
     if timestamp is not None:
         tz_label = timestamp.strftime("%Z") or tz_name or "UTC"
         parts.append(timestamp.strftime("%d/%m/%y"))
@@ -294,10 +299,7 @@ def _draw_frame_label(
 
     # --- Top-left: location name ---
     if location_name:
-        name = location_name
-        if len(name) > 30:
-            name = name[:29] + "\u2026"
-        _draw_text_with_outline(draw, padding, padding, name, font)
+        _draw_text_with_outline(draw, padding, padding, _truncate_location(location_name), font)
 
     # --- Top-centre: date/time ---
     if timestamp is not None:

--- a/tests/unit/radar/test_attribution.py
+++ b/tests/unit/radar/test_attribution.py
@@ -118,13 +118,15 @@ def test_draw_attribution_frame_label_position_is_top():
     After calling _draw_frame_label, the top strip should have non-black pixels
     and the very bottom strip should remain black (no text overlap between label and attribution).
     This verifies the layout separation: label at top, attribution at bottom.
+
+    Now also accepts frame_index and frame_count parameters for the frame counter.
     """
     from custom_components.rain_incoming.radar.composite import _draw_frame_label
     from datetime import datetime, timezone
 
     img = _blank_image()
     ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
-    _draw_frame_label(img, ts, "UTC", 128, "Sydney")
+    _draw_frame_label(img, ts, "UTC", 128, "Sydney", frame_index=3, frame_count=13)
 
     arr = np.array(img)[:, :, :3]
     h = arr.shape[0]
@@ -145,6 +147,171 @@ def test_draw_attribution_frame_label_position_is_top():
         f"Expected no frame label pixels in the bottom strip, "
         f"but found {bottom_nonblack} non-black pixels. Label may still be at the bottom."
     )
+
+
+# ---------------------------------------------------------------------------
+# New header layout: location (left), date/time (centre), range+counter (right)
+# ---------------------------------------------------------------------------
+
+def test_draw_frame_label_renders_frame_counter():
+    """_draw_frame_label must render the frame counter text (e.g. '3/13').
+
+    Mocks ImageDraw.text to capture all text rendered, then asserts that
+    at least one call includes a string matching the 'N/M' frame counter pattern.
+    """
+    from unittest.mock import patch
+    from datetime import datetime, timezone
+    from PIL import ImageDraw
+    from custom_components.rain_incoming.radar.composite import _draw_frame_label
+
+    img = _blank_image()
+    ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+
+    with patch.object(ImageDraw.ImageDraw, "text") as mock_text:
+        _draw_frame_label(img, ts, "UTC", 128, "Sydney", frame_index=3, frame_count=13)
+
+    all_text_strings = [
+        c.args[1] for c in mock_text.call_args_list
+        if len(c.args) >= 2 and isinstance(c.args[1], str)
+    ]
+
+    counter_calls = [s for s in all_text_strings if "3/13" in s]
+    assert counter_calls, (
+        f"Expected at least one draw.text call containing '3/13' for the frame counter, "
+        f"but none found. All rendered strings: {all_text_strings}"
+    )
+
+
+def test_draw_frame_label_location_drawn_at_left():
+    """Location name must be drawn near the left edge (x close to padding).
+
+    Verifies that 'Sydney' appears in a draw.text call with an x-coordinate
+    close to the padding value (8px), i.e. anchored at the left.
+    """
+    from unittest.mock import patch
+    from datetime import datetime, timezone
+    from PIL import ImageDraw
+    from custom_components.rain_incoming.radar.composite import _draw_frame_label
+
+    img = _blank_image()
+    ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+
+    with patch.object(ImageDraw.ImageDraw, "text") as mock_text:
+        _draw_frame_label(img, ts, "UTC", 128, "Sydney", frame_index=1, frame_count=5)
+
+    # Find the call that draws "Sydney"
+    sydney_calls = [
+        c for c in mock_text.call_args_list
+        if len(c.args) >= 2 and isinstance(c.args[1], str) and "Sydney" in c.args[1]
+    ]
+    assert sydney_calls, (
+        f"Expected a draw.text call containing 'Sydney', but none found. "
+        f"All calls: {[c.args for c in mock_text.call_args_list]}"
+    )
+
+    # The x coordinate of the position tuple should be close to left padding (8)
+    # We accept any call where x < img.width // 3 (clearly on the left third)
+    left_threshold = img.width // 3  # 213px for a 640px image
+    for call in sydney_calls:
+        pos = call.args[0]
+        x = pos[0]
+        if x < left_threshold:
+            break  # found at least one left-anchored call
+    else:
+        xs = [c.args[0][0] for c in sydney_calls]
+        assert False, (
+            f"'Sydney' was drawn but not near the left edge. "
+            f"x-coordinates: {xs}, left threshold: {left_threshold}px (img width: {img.width})"
+        )
+
+
+def test_draw_frame_label_datetime_drawn_at_centre():
+    """Date/time must be drawn near the horizontal centre of the image.
+
+    Verifies a draw.text call with the date string has an x-coordinate
+    near img.width // 2, using anchor='mt' (middle-top).
+    """
+    from unittest.mock import patch
+    from datetime import datetime, timezone
+    from PIL import ImageDraw
+    from custom_components.rain_incoming.radar.composite import _draw_frame_label
+
+    img = _blank_image()  # 640px wide
+    ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+
+    with patch.object(ImageDraw.ImageDraw, "text") as mock_text:
+        _draw_frame_label(img, ts, "UTC", 128, "Sydney", frame_index=2, frame_count=10)
+
+    # Date or time substring to find the centre text call
+    # The date is "10/04/26" and time is "20:40 UTC"
+    centre_calls = [
+        c for c in mock_text.call_args_list
+        if len(c.args) >= 2 and isinstance(c.args[1], str)
+        and ("10/04/26" in c.args[1] or "20:40" in c.args[1])
+    ]
+    assert centre_calls, (
+        f"Expected a draw.text call containing date/time ('10/04/26' or '20:40'), "
+        f"but none found. All strings: {[c.args[1] for c in mock_text.call_args_list if len(c.args) >= 2 and isinstance(c.args[1], str)]}"
+    )
+
+    # x should be close to the centre (320px for 640px image)
+    # Accept anchor='mt' style: x == img.width // 2 (within 20px tolerance)
+    centre_x = img.width // 2  # 320
+    tolerance = 20
+    for call in centre_calls:
+        pos = call.args[0]
+        x = pos[0]
+        if abs(x - centre_x) <= tolerance:
+            break
+    else:
+        xs = [c.args[0][0] for c in centre_calls]
+        assert False, (
+            f"Date/time text was drawn but not near the centre. "
+            f"x-coordinates: {xs}, expected ~{centre_x}px (±{tolerance}px)"
+        )
+
+
+def test_draw_frame_label_range_drawn_at_right():
+    """Range text (e.g. '128km') must be drawn near the right edge of the image.
+
+    Verifies a draw.text call containing the range string has an x-coordinate
+    near img.width - padding, indicating right-anchored placement.
+    """
+    from unittest.mock import patch
+    from datetime import datetime, timezone
+    from PIL import ImageDraw
+    from custom_components.rain_incoming.radar.composite import _draw_frame_label
+
+    img = _blank_image()  # 640px wide
+    ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+
+    with patch.object(ImageDraw.ImageDraw, "text") as mock_text:
+        _draw_frame_label(img, ts, "UTC", 128, "Sydney", frame_index=1, frame_count=5)
+
+    # Find calls containing the range text
+    range_calls = [
+        c for c in mock_text.call_args_list
+        if len(c.args) >= 2 and isinstance(c.args[1], str) and "128km" in c.args[1]
+    ]
+    assert range_calls, (
+        f"Expected a draw.text call containing '128km', but none found. "
+        f"All strings: {[c.args[1] for c in mock_text.call_args_list if len(c.args) >= 2 and isinstance(c.args[1], str)]}"
+    )
+
+    # x should be near the right edge. With anchor='rt', x == img.width - padding.
+    # Accept any x >= img.width * 2 // 3 (right third of image)
+    right_threshold = img.width * 2 // 3  # ~427px for 640px image
+    for call in range_calls:
+        pos = call.args[0]
+        x = pos[0]
+        if x >= right_threshold:
+            break
+    else:
+        xs = [c.args[0][0] for c in range_calls]
+        assert False, (
+            f"Range text '128km' was drawn but not near the right edge. "
+            f"x-coordinates: {xs}, right threshold: {right_threshold}px (img width: {img.width})"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/radar/test_attribution.py
+++ b/tests/unit/radar/test_attribution.py
@@ -314,6 +314,108 @@ def test_draw_frame_label_range_drawn_at_right():
         )
 
 
+def test_draw_frame_label_no_counter_when_indices_omitted():
+    """When frame_index/frame_count are None, no slash counter appears in any text."""
+    from unittest.mock import patch
+    from datetime import datetime, timezone
+    from PIL import ImageDraw
+    from custom_components.rain_incoming.radar.composite import _draw_frame_label
+
+    img = _blank_image()
+    ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+
+    with patch.object(ImageDraw.ImageDraw, "text") as mock_text:
+        _draw_frame_label(img, ts, "UTC", 128, "Sydney")
+
+    all_strings = [
+        c.args[1] for c in mock_text.call_args_list
+        if len(c.args) >= 2 and isinstance(c.args[1], str)
+    ]
+    # The range text should be just "128km" with no "N/M" counter appended.
+    range_strings = [s for s in all_strings if "128km" in s]
+    assert range_strings, f"Expected '128km' in draw calls, got: {all_strings}"
+    for s in range_strings:
+        assert s.strip() == "128km", (
+            f"Range text should be exactly '128km' when no frame counter, got: {s!r}"
+        )
+
+
+def test_draw_frame_label_no_location_no_crash():
+    """_draw_frame_label with location_name=None must not crash or draw 'None'."""
+    from unittest.mock import patch
+    from datetime import datetime, timezone
+    from PIL import ImageDraw
+    from custom_components.rain_incoming.radar.composite import _draw_frame_label
+
+    img = _blank_image()
+    ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+
+    with patch.object(ImageDraw.ImageDraw, "text") as mock_text:
+        _draw_frame_label(img, ts, "UTC", 128, None, frame_index=1, frame_count=5)
+
+    all_strings = [
+        c.args[1] for c in mock_text.call_args_list
+        if len(c.args) >= 2 and isinstance(c.args[1], str)
+    ]
+    none_strings = [s for s in all_strings if "None" in s]
+    assert not none_strings, (
+        f"'None' should never appear in rendered text, but found: {none_strings}"
+    )
+
+
+def test_draw_frame_label_no_timestamp_no_crash():
+    """_draw_frame_label with timestamp=None must not crash or draw date text."""
+    from unittest.mock import patch
+    from PIL import ImageDraw
+    from custom_components.rain_incoming.radar.composite import _draw_frame_label
+
+    img = _blank_image()
+
+    with patch.object(ImageDraw.ImageDraw, "text") as mock_text:
+        _draw_frame_label(img, None, None, 128, "Sydney", frame_index=1, frame_count=5)
+
+    all_strings = [
+        c.args[1] for c in mock_text.call_args_list
+        if len(c.args) >= 2 and isinstance(c.args[1], str)
+    ]
+    # Should still have location and range, but no date/time
+    assert any("Sydney" in s for s in all_strings), f"Location should appear: {all_strings}"
+    assert any("128km" in s for s in all_strings), f"Range should appear: {all_strings}"
+    date_strings = [s for s in all_strings if "/" in s and len(s) > 5 and any(c.isdigit() for c in s[:2])]
+    # Filter out "1/5" frame counter - we're looking for date-like patterns "DD/MM/YY"
+    date_like = [s for s in all_strings if any(sub in s for sub in ["26", "2026"])]
+    assert not date_like, (
+        f"No date text should be drawn when timestamp is None, but found: {date_like}"
+    )
+
+
+def test_draw_frame_label_truncates_long_location():
+    """_draw_frame_label must truncate location names > 30 chars via the live code path."""
+    from unittest.mock import patch
+    from datetime import datetime, timezone
+    from PIL import ImageDraw
+    from custom_components.rain_incoming.radar.composite import _draw_frame_label
+
+    img = _blank_image()
+    ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
+    long_name = "A" * 40
+
+    with patch.object(ImageDraw.ImageDraw, "text") as mock_text:
+        _draw_frame_label(img, ts, "UTC", 128, long_name, frame_index=1, frame_count=5)
+
+    all_strings = [
+        c.args[1] for c in mock_text.call_args_list
+        if len(c.args) >= 2 and isinstance(c.args[1], str)
+    ]
+    truncated = "A" * 29 + "\u2026"
+    assert any(truncated in s for s in all_strings), (
+        f"Expected truncated location '{truncated}' in draw calls, got: {all_strings}"
+    )
+    assert not any(long_name in s for s in all_strings), (
+        f"Full 40-char name should not appear untruncated, got: {all_strings}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # P0 regression: render_composite must pass style_def through _render_sync
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Splits the single top-left frame label into three positioned elements: location (left), date/time (centre), range + frame counter (right)
- Adds frame counter (e.g. "3/13") to the top-right alongside range
- Extracts `_truncate_location` helper shared by `build_frame_label` and `_draw_frame_label` to eliminate duplicated truncation logic

## Changes
- `radar/composite.py`: new `_draw_text_with_outline_anchored()` helper for Pillow anchors (`mt`, `rt`), refactored `_draw_frame_label`, new `_truncate_location` helper, threaded `frame_index`/`frame_count` through call chain
- `tests/unit/radar/test_attribution.py`: 8 new tests - position verification (left/centre/right), frame counter presence, frame counter suppression, null-path coverage (no location, no timestamp), truncation via live code path

## Test plan
- [x] `python -m pytest tests/unit tests/integration` - 371 green
- [x] Pre-push hook green
- [x] Frame counter verified via mock: "3/13" appears in range text
- [x] Counter suppression verified: "128km" only when indices omitted
- [x] Null paths verified: no crash or "None" text with missing location/timestamp
- [x] Truncation verified through live `_draw_frame_label` path (not just `build_frame_label`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)