### PR TITLE
fix: white text on dark map styles + expand README attribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,22 @@ Bug reports, feature requests, and PRs are welcome. See [CONTRIBUTING.md](CONTRI
 
 ## Attribution
 
-Radar data provided by [RainViewer](https://www.rainviewer.com/). Free for personal and educational use with attribution.
+**Radar data:** [RainViewer](https://www.rainviewer.com/) - free for personal and educational use with attribution. See [RainViewer API terms](https://www.rainviewer.com/api.html).
+
+**Map tiles** (depending on selected style):
+
+| Style | Provider | Attribution |
+|---|---|---|
+| CARTO Voyager _(default)_ | [CARTO](https://carto.com/) | © CARTO, © OpenStreetMap contributors |
+| OpenStreetMap | [OpenStreetMap](https://www.openstreetmap.org/) | © OpenStreetMap contributors |
+| OpenStreetMap Dark | [OpenStreetMap](https://www.openstreetmap.org/) | © OpenStreetMap contributors |
+| ESRI Satellite Imagery | [Esri](https://www.esri.com/) | Sources: Esri, Maxar, Earthstar Geographics, and the GIS User Community |
+| Dark Matter | [CARTO](https://carto.com/) | © CARTO, © OpenStreetMap contributors |
+
+OpenStreetMap data is available under the [Open Database License](https://opendatacommons.org/licenses/odbl/).
+CARTO tiles are provided under [CARTO's basemap service terms](https://carto.com/legal/).
+
+These attributions are also displayed on every radar image rendered by the integration.
 
 ## License
 

--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -173,6 +173,7 @@ def draw_crosshair(img: Image.Image, cx: int, cy: int) -> None:
 
 def draw_range_rings(
     img: Image.Image, cx: int, cy: int, full_radius_px: int, radius_km: int,
+    is_dark: bool = False,
 ) -> None:
     """Draw subtle range rings at half-radius and full-radius with distance labels."""
     draw = ImageDraw.Draw(img)
@@ -193,12 +194,7 @@ def draw_range_rings(
         tw, th = bbox[2] - bbox[0], bbox[3] - bbox[1]
         lx = cx + 4
         ly = cy - r - th - 2
-        # White outline for readability
-        for dx in (-1, 0, 1):
-            for dy in (-1, 0, 1):
-                if dx or dy:
-                    draw.text((lx + dx, ly + dy), label, fill=(255, 255, 255, 255), font=font)
-        draw.text((lx, ly), label, fill=(0, 0, 0, 200), font=font)
+        _draw_text_with_outline(draw, lx, ly, label, font, is_dark=is_dark)
 
 
 async def _fetch_tile(session: aiohttp.ClientSession, url: str) -> Image.Image:
@@ -282,6 +278,7 @@ def _draw_frame_label(
     *,
     frame_index: int | None = None,
     frame_count: int | None = None,
+    is_dark: bool = False,
 ) -> None:
     """Draw header labels across the top of a frame in three positions.
 
@@ -299,21 +296,21 @@ def _draw_frame_label(
 
     # --- Top-left: location name ---
     if location_name:
-        _draw_text_with_outline(draw, padding, padding, _truncate_location(location_name), font)
+        _draw_text_with_outline(draw, padding, padding, _truncate_location(location_name), font, is_dark=is_dark)
 
     # --- Top-centre: date/time ---
     if timestamp is not None:
         tz_label = timestamp.strftime("%Z") or tz_name or "UTC"
         datetime_text = f"{timestamp.strftime('%d/%m/%y')}  {timestamp.strftime(f'%H:%M {tz_label}')}"
         cx = img.width // 2
-        _draw_text_with_outline_anchored(draw, cx, padding, datetime_text, font, anchor="mt")
+        _draw_text_with_outline_anchored(draw, cx, padding, datetime_text, font, anchor="mt", is_dark=is_dark)
 
     # --- Top-right: range + frame counter ---
     range_text = f"{radius_km}km"
     if frame_index is not None and frame_count is not None:
         range_text = f"{range_text}  {frame_index}/{frame_count}"
     rx = img.width - padding
-    _draw_text_with_outline_anchored(draw, rx, padding, range_text, font, anchor="rt")
+    _draw_text_with_outline_anchored(draw, rx, padding, range_text, font, anchor="rt", is_dark=is_dark)
 
 
 def _draw_attribution(img: Image.Image, style_def: MapStyleDefinition) -> None:
@@ -337,7 +334,14 @@ def _draw_attribution(img: Image.Image, style_def: MapStyleDefinition) -> None:
     lx = padding
     ly = img.height - text_h - padding
 
-    _draw_text_with_outline(draw, lx, ly, text, font)
+    _draw_text_with_outline(draw, lx, ly, text, font, is_dark=style_def.is_dark)
+
+
+def _text_colours(is_dark: bool) -> tuple[tuple, tuple]:
+    """Return (outline_colour, fill_colour) for text on light or dark backgrounds."""
+    if is_dark:
+        return (0, 0, 0, 200), (255, 255, 255, 230)
+    return (255, 255, 255, 220), (0, 0, 0, 230)
 
 
 def _draw_text_with_outline(
@@ -346,13 +350,19 @@ def _draw_text_with_outline(
     y: int,
     text: str,
     font,
+    is_dark: bool = False,
 ) -> None:
-    """Draw text with a white outline and dark fill for readability on any background."""
+    """Draw text with a contrasting outline for readability on any background.
+
+    On light maps: black text, white outline.
+    On dark maps: white text, black outline.
+    """
+    outline, fill = _text_colours(is_dark)
     for dx in (-1, 0, 1):
         for dy in (-1, 0, 1):
             if dx or dy:
-                draw.text((x + dx, y + dy), text, fill=(255, 255, 255, 220), font=font)
-    draw.text((x, y), text, fill=(0, 0, 0, 230), font=font)
+                draw.text((x + dx, y + dy), text, fill=outline, font=font)
+    draw.text((x, y), text, fill=fill, font=font)
 
 
 def _draw_text_with_outline_anchored(
@@ -362,19 +372,21 @@ def _draw_text_with_outline_anchored(
     text: str,
     font,
     anchor: str = "la",
+    is_dark: bool = False,
 ) -> None:
-    """Draw text with a white outline using a Pillow text anchor.
+    """Draw text with a contrasting outline using a Pillow text anchor.
 
     anchor='mt' for top-centre, anchor='rt' for top-right, anchor='la' for top-left.
     """
+    outline, fill = _text_colours(is_dark)
     for dx in (-1, 0, 1):
         for dy in (-1, 0, 1):
             if dx or dy:
                 draw.text(
                     (x + dx, y + dy), text,
-                    fill=(255, 255, 255, 220), font=font, anchor=anchor,
+                    fill=outline, font=font, anchor=anchor,
                 )
-    draw.text((x, y), text, fill=(0, 0, 0, 230), font=font, anchor=anchor)
+    draw.text((x, y), text, fill=fill, font=font, anchor=anchor)
 
 
 def _composite_single_frame(
@@ -436,16 +448,18 @@ def _composite_single_frame(
     radius_px = int(radius_km / kpp) if kpp > 0 else output_size // 2
 
     cx, cy = output_size // 2, output_size // 2
-    draw_range_rings(composite, cx, cy, radius_px, radius_km)
+    if style_def is None:
+        style_def = get_style(MapStyle.VOYAGER)
+
+    draw_range_rings(composite, cx, cy, radius_px, radius_km, is_dark=style_def.is_dark)
     draw_crosshair(composite, cx, cy)
 
     _draw_frame_label(
         composite, timestamp, tz_name, radius_km, location_name,
         frame_index=frame_index, frame_count=frame_count,
+        is_dark=style_def.is_dark,
     )
 
-    if style_def is None:
-        style_def = get_style(MapStyle.VOYAGER)
     _draw_attribution(composite, style_def)
 
     return composite

--- a/custom_components/rain_incoming/radar/map_styles.py
+++ b/custom_components/rain_incoming/radar/map_styles.py
@@ -49,6 +49,7 @@ class MapStyleDefinition:
     display_name: str
     attribution: str
     fetch_tile: FetchTileFn
+    is_dark: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -186,6 +187,7 @@ _STYLES: dict[MapStyle, MapStyleDefinition] = {
         display_name="OpenStreetMap Dark",
         attribution="© OpenStreetMap contributors",
         fetch_tile=_fetch_osm_dark,
+        is_dark=True,
     ),
     MapStyle.ESRI_IMAGERY: MapStyleDefinition(
         style=MapStyle.ESRI_IMAGERY,
@@ -198,6 +200,7 @@ _STYLES: dict[MapStyle, MapStyleDefinition] = {
         display_name="Dark Matter",
         attribution="© CARTO, © OpenStreetMap contributors",
         fetch_tile=_fetch_dark_matter,
+        is_dark=True,
     ),
 }
 


### PR DESCRIPTION
## Summary

- Annotations (header labels, range ring distances, bottom attribution) were using black text with white outline, which is unreadable on Dark Matter and OpenStreetMap Dark backgrounds
- `MapStyleDefinition` gets `is_dark: bool` - `True` for `osm_dark` and `dark_matter`
- On dark styles: white text with black outline. On light styles: existing black text with white outline (unchanged)
- Expanded README Attribution section with a per-style table covering all five map providers plus links to terms

## Test plan

- [ ] Switch to Dark Matter or OSM Dark in Configure and verify header/labels/attribution are legible (white text)
- [ ] Switch to Voyager/OSM Standard/ESRI and verify labels remain black (unchanged)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)