### PR TITLE
chore: bump version to 0.1.1

### DIFF
--- a/custom_components/rain_incoming/manifest.json
+++ b/custom_components/rain_incoming/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "rain_incoming",
   "name": "Rain Incoming",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "documentation": "https://github.com/abrainwood/home-assistant-rain-incoming",
   "requirements": ["numpy>=1.26", "scipy>=1.11"],
   "dependencies": [],


### PR DESCRIPTION
Bumps `manifest.json` version from `0.1.0` → `0.1.1` to use as the base for the next batch of changes. HACS will show this as the installed version after update.