### PR TITLE
chore: add issue_tracker to manifest.json

### DIFF
--- a/custom_components/rain_incoming/manifest.json
+++ b/custom_components/rain_incoming/manifest.json
@@ -3,6 +3,7 @@
   "name": "Rain Incoming",
   "version": "0.1.1",
   "documentation": "https://github.com/abrainwood/home-assistant-rain-incoming",
+  "issue_tracker": "https://github.com/abrainwood/home-assistant-rain-incoming/issues",
   "requirements": ["numpy>=1.26", "scipy>=1.11"],
   "dependencies": [],
   "codeowners": ["@abrainwood"],


### PR DESCRIPTION
Adds the `issue_tracker` field to `manifest.json` as recommended by HACS publishing guidelines.