### PR TITLE
fix: downgrade slow tile fetch log from WARNING to DEBUG

### DIFF
--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -648,6 +648,9 @@ async def _fetch_radar_overlay(
             tile = await _fetch_tile(session, url)
             elapsed = _time.monotonic() - t0
             if elapsed > 5:
+                # DEBUG not WARNING: at WARNING this floods the HA system log
+                # (~36 entries per 10-minute poll) and triggers HA's internal log
+                # throttler. Slow-but-successful fetches are not actionable for users.
                 _LOGGER.debug(
                     "Slow tile fetch: %.1fs for z=%d x=%d y=%d (%s)",
                     elapsed, radar_zoom, tx, ty, frame_path[-8:],

--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -648,7 +648,7 @@ async def _fetch_radar_overlay(
             tile = await _fetch_tile(session, url)
             elapsed = _time.monotonic() - t0
             if elapsed > 5:
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "Slow tile fetch: %.1fs for z=%d x=%d y=%d (%s)",
                     elapsed, radar_zoom, tx, ty, frame_path[-8:],
                 )


### PR DESCRIPTION
Slow tile fetches (~36 per poll cycle) were logged at WARNING, causing HA's internal log throttler to trigger. These fetches always succeed - the latency is expected from overseas CDNs. Downgraded to DEBUG.