### PR TITLE
fix: reduce location name limit to 16 chars

### DIFF
--- a/custom_components/rain_incoming/const.py
+++ b/custom_components/rain_incoming/const.py
@@ -5,8 +5,9 @@ CONF_LOCATION_NAME = "location_name"
 CONF_LOOKAHEAD_MINUTES = "lookahead_minutes"
 CONF_MAP_STYLE = "map_style"
 
-# Location name display limit (chars). Longer names overlap the attribution line.
-MAX_LOCATION_NAME_CHARS = 30
+# Location name display limit (chars). Names longer than this overflow the
+# date/time field in the radar image header at all three zoom levels.
+MAX_LOCATION_NAME_CHARS = 16
 
 # Maximum number of rain_incoming locations a user can configure.
 # RainViewer's free tier rate-limits parallel tile fetching across multiple

--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -238,7 +238,7 @@ async def _fetch_map_tile(
     return tile
 
 
-def _truncate_location(name: str, max_len: int = 30) -> str:
+def _truncate_location(name: str, max_len: int = 16) -> str:
     """Truncate a location name to max_len chars, adding ellipsis if needed."""
     if len(name) > max_len:
         return name[:max_len - 1] + "\u2026"
@@ -255,8 +255,8 @@ def build_frame_label(
 
     Format: "Location  DD/MM/YY  HH:MM TZ  Rangekm"
     Location is omitted if not set.
-    Location names > 30 chars are truncated to 29 chars + ellipsis as a
-    render-time safety net (config validation is PR 3's job).
+    Location names > 16 chars are truncated to 15 chars + ellipsis as a
+    render-time safety net (config validation enforces MAX_LOCATION_NAME_CHARS).
     """
     parts = []
     if location_name:

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -159,7 +159,7 @@ async def test_config_flow_rejects_lookahead_out_of_range(hass: HomeAssistant):
 
 
 @pytest.mark.asyncio
-async def test_config_flow_rejects_location_name_over_30_chars(hass: HomeAssistant):
+async def test_config_flow_rejects_location_name_over_16_chars(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "user"}
     )
@@ -168,7 +168,7 @@ async def test_config_flow_rejects_location_name_over_30_chars(hass: HomeAssista
         {
             "location": _loc(),
             "lookahead_minutes": 60,
-            "location_name": "A" * 40,
+            "location_name": "A" * 17,
         },
     )
     assert result["type"] == FlowResultType.FORM
@@ -256,7 +256,7 @@ async def test_options_flow_changes_map_style(hass: HomeAssistant):
 
 
 @pytest.mark.asyncio
-async def test_options_flow_rejects_location_name_over_30_chars(hass: HomeAssistant):
+async def test_options_flow_rejects_location_name_over_16_chars(hass: HomeAssistant):
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
@@ -273,7 +273,7 @@ async def test_options_flow_rejects_location_name_over_30_chars(hass: HomeAssist
     result = await hass.config_entries.options.async_configure(
         result["flow_id"],
         {
-            "location_name": "B" * 40,
+            "location_name": "B" * 17,
             "lookahead_minutes": 60,
             CONF_MAP_STYLE: "voyager",
         },
@@ -486,7 +486,7 @@ async def test_options_flow_schedules_reload_after_save(hass: HomeAssistant):
 
 
 @pytest.mark.asyncio
-async def test_config_flow_accepts_location_name_exactly_30_chars(hass: HomeAssistant):
+async def test_config_flow_accepts_location_name_exactly_16_chars(hass: HomeAssistant):
     result = await hass.config_entries.flow.async_init(
         DOMAIN, context={"source": "user"}
     )
@@ -495,11 +495,11 @@ async def test_config_flow_accepts_location_name_exactly_30_chars(hass: HomeAssi
         {
             "location": _loc(),
             "lookahead_minutes": 60,
-            "location_name": "A" * 30,
+            "location_name": "A" * 16,
         },
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert result["data"][CONF_LOCATION_NAME] == "A" * 30
+    assert result["data"][CONF_LOCATION_NAME] == "A" * 16
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/radar/test_attribution.py
+++ b/tests/unit/radar/test_attribution.py
@@ -390,11 +390,12 @@ def test_draw_frame_label_no_timestamp_no_crash():
 
 
 def test_draw_frame_label_truncates_long_location():
-    """_draw_frame_label must truncate location names > 30 chars via the live code path."""
+    """_draw_frame_label must truncate location names over the limit via the live code path."""
     from unittest.mock import patch
     from datetime import datetime, timezone
     from PIL import ImageDraw
     from custom_components.rain_incoming.radar.composite import _draw_frame_label
+    from custom_components.rain_incoming.const import MAX_LOCATION_NAME_CHARS
 
     img = _blank_image()
     ts = datetime(2026, 4, 10, 20, 40, 0, tzinfo=timezone.utc)
@@ -407,7 +408,7 @@ def test_draw_frame_label_truncates_long_location():
         c.args[1] for c in mock_text.call_args_list
         if len(c.args) >= 2 and isinstance(c.args[1], str)
     ]
-    truncated = "A" * 29 + "\u2026"
+    truncated = "A" * (MAX_LOCATION_NAME_CHARS - 1) + "\u2026"
     assert any(truncated in s for s in all_strings), (
         f"Expected truncated location '{truncated}' in draw calls, got: {all_strings}"
     )

--- a/tests/unit/radar/test_composite_map_styles.py
+++ b/tests/unit/radar/test_composite_map_styles.py
@@ -5,8 +5,8 @@ TDD: written FIRST (red), then implementation makes them green.
 Covers:
 - fetch_map_crop defaults to VOYAGER style
 - fetch_map_crop passes the style parameter through to the correct fetch_tile
-- build_frame_label truncates location names > 30 chars
-- build_frame_label leaves names <= 30 chars untouched
+- build_frame_label truncates location names over MAX_LOCATION_NAME_CHARS
+- build_frame_label leaves names <= MAX_LOCATION_NAME_CHARS untouched
 """
 from __future__ import annotations
 
@@ -21,6 +21,7 @@ from custom_components.rain_incoming.radar.composite import (
     fetch_map_crop,
 )
 from custom_components.rain_incoming.radar.map_styles import MapStyle
+from custom_components.rain_incoming.const import MAX_LOCATION_NAME_CHARS
 
 
 # ---------------------------------------------------------------------------
@@ -127,12 +128,12 @@ async def test_fetch_map_crop_passes_style_through(style: MapStyle, url_fragment
 # ---------------------------------------------------------------------------
 
 def test_build_frame_label_truncates_long_location_names():
-    """Location names > 30 chars must be truncated to 29 chars + ellipsis."""
+    """Location names over MAX_LOCATION_NAME_CHARS must be truncated to (limit-1) chars + ellipsis."""
     long_name = "A" * 40  # 40 chars - clearly over the limit
     label = build_frame_label(
         timestamp=None, tz_name=None, radius_km=128, location_name=long_name,
     )
-    truncated = "A" * 29 + "\u2026"
+    truncated = "A" * (MAX_LOCATION_NAME_CHARS - 1) + "\u2026"
     assert truncated in label, (
         f"Expected truncated name {truncated!r} in label, got: {label!r}"
     )
@@ -140,44 +141,46 @@ def test_build_frame_label_truncates_long_location_names():
         f"Full 40-char name should not appear in label, got: {label!r}"
     )
 
-    # Boundary case: 31 chars is the FIRST length that triggers truncation.
+    # Boundary case: MAX_LOCATION_NAME_CHARS + 1 is the FIRST length that triggers truncation.
     # Off-by-one bugs live here (e.g. > vs >= in the length check).
-    name_31 = "D" * 31
-    label_31 = build_frame_label(
-        timestamp=None, tz_name=None, radius_km=128, location_name=name_31,
+    name_over = "D" * (MAX_LOCATION_NAME_CHARS + 1)
+    label_over = build_frame_label(
+        timestamp=None, tz_name=None, radius_km=128, location_name=name_over,
     )
-    truncated_31 = "D" * 29 + "\u2026"
-    assert truncated_31 in label_31, (
-        f"31-char name should be truncated to 29 chars + ellipsis, got: {label_31!r}"
+    truncated_over = "D" * (MAX_LOCATION_NAME_CHARS - 1) + "\u2026"
+    assert truncated_over in label_over, (
+        f"{MAX_LOCATION_NAME_CHARS + 1}-char name should be truncated to "
+        f"{MAX_LOCATION_NAME_CHARS - 1} chars + ellipsis, got: {label_over!r}"
     )
-    assert name_31 not in label_31, (
-        f"Full 31-char name should not appear in label, got: {label_31!r}"
+    assert name_over not in label_over, (
+        f"Full {MAX_LOCATION_NAME_CHARS + 1}-char name should not appear in label, got: {label_over!r}"
     )
 
-    # Boundary just below: 30-char name must NOT be truncated
-    name_30_boundary = "E" * 30
-    label_30 = build_frame_label(
-        timestamp=None, tz_name=None, radius_km=128, location_name=name_30_boundary,
+    # Boundary just below: MAX_LOCATION_NAME_CHARS-char name must NOT be truncated
+    name_boundary = "E" * MAX_LOCATION_NAME_CHARS
+    label_boundary = build_frame_label(
+        timestamp=None, tz_name=None, radius_km=128, location_name=name_boundary,
     )
-    assert name_30_boundary in label_30, (
-        f"30-char name (on the boundary) should NOT be truncated, got: {label_30!r}"
+    assert name_boundary in label_boundary, (
+        f"{MAX_LOCATION_NAME_CHARS}-char name (on the boundary) should NOT be truncated, "
+        f"got: {label_boundary!r}"
     )
 
 
 def test_build_frame_label_leaves_short_names_intact():
-    """Location names <= 30 chars must not be truncated."""
-    name_30 = "B" * 30  # exactly 30 chars - on the boundary
+    """Location names <= MAX_LOCATION_NAME_CHARS must not be truncated."""
+    name_at_limit = "B" * MAX_LOCATION_NAME_CHARS  # exactly at the limit
     label = build_frame_label(
-        timestamp=None, tz_name=None, radius_km=128, location_name=name_30,
+        timestamp=None, tz_name=None, radius_km=128, location_name=name_at_limit,
     )
-    assert name_30 in label, (
-        f"30-char name should appear unchanged in label, got: {label!r}"
+    assert name_at_limit in label, (
+        f"{MAX_LOCATION_NAME_CHARS}-char name should appear unchanged in label, got: {label!r}"
     )
 
-    name_29 = "C" * 29  # 29 chars - under the limit
+    name_under = "C" * (MAX_LOCATION_NAME_CHARS - 1)  # one under the limit
     label2 = build_frame_label(
-        timestamp=None, tz_name=None, radius_km=128, location_name=name_29,
+        timestamp=None, tz_name=None, radius_km=128, location_name=name_under,
     )
-    assert name_29 in label2, (
-        f"29-char name should appear unchanged in label, got: {label2!r}"
+    assert name_under in label2, (
+        f"{MAX_LOCATION_NAME_CHARS - 1}-char name should appear unchanged in label, got: {label2!r}"
     )


### PR DESCRIPTION
Fixes #72.

Location names up to 30 chars were allowed but overflowed the date/time field in the radar image header at all three zoom levels. 20 chars was still too long. Empirically 16 is the maximum that fits.

## Changes
- `MAX_LOCATION_NAME_CHARS`: 30 → 16 in `const.py`
- `_truncate_location` default `max_len`: 30 → 16 in `composite.py`
- All tests updated to import `MAX_LOCATION_NAME_CHARS` from production instead of hardcoding the threshold

## Test plan
- [ ] `tests/unit/radar/test_composite_map_styles.py` - boundary tests now use `MAX_LOCATION_NAME_CHARS ± 1`
- [ ] `tests/unit/radar/test_attribution.py` - truncation assertion uses `MAX_LOCATION_NAME_CHARS - 1`
- [ ] `tests/integration/test_config_flow.py` - config/options flow rejects names > 16 chars, accepts exactly 16
- [ ] Full unit + integration suite: 393 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)