### PR TITLE
feat: read RainViewer rate limit headers and adapt pacing dynamically

### DIFF
--- a/custom_components/rain_incoming/coordinator.py
+++ b/custom_components/rain_incoming/coordinator.py
@@ -48,6 +48,7 @@ from .const import (
     RAINVIEWER_ZOOM,
     RAINVIEWER_TILE_SIZE,
 )
+from .http_retry import RateLimitBudget
 from .providers.base import BoundingBox
 from .providers.rainviewer import RainViewerProvider
 from .radar.detector import Confidence, DetectionResult, DetectorConfig, TrackedCell, detect
@@ -150,6 +151,9 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
         # Avoids re-fetching tile grids for frames that haven't changed between polls.
         self._frame_cache: dict[str, object] = {}
 
+        # Rate limit budget - shared across all tile fetches in a polling cycle
+        self._rate_limit_budget = RateLimitBudget()
+
     @property
     def map_style(self) -> str:
         """Return the active map style, reading options first then data then default."""
@@ -220,7 +224,7 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
 
         async def _fetch_frame(frame):
             try:
-                await frame._fetch_stitched_grid(bounds, W, H, session)
+                await frame._fetch_stitched_grid(bounds, W, H, session, budget=self._rate_limit_budget)
             except aiohttp.ClientResponseError as e:
                 _LOGGER.warning(
                     "Radar grid fetch failed: HTTP %d for frame %s",

--- a/custom_components/rain_incoming/http_retry.py
+++ b/custom_components/rain_incoming/http_retry.py
@@ -11,6 +11,73 @@ _LOGGER = logging.getLogger(__name__)
 # Default concurrency limit for tile fetches
 DEFAULT_CONCURRENT_LIMIT = 10
 
+_UTILIZATION_THRESHOLD = 0.80
+
+
+class RateLimitBudget:
+    """Tracks RainViewer rate limit state from response headers."""
+
+    def __init__(self) -> None:
+        self._limit: int = 0
+        self._used: int = 0
+        self._window_seconds: float = 0.0
+        self._burst_limit: int = 0
+        self._burst_used: int = 0
+
+    def update_from_headers(self, headers) -> None:
+        """Parse x-ratelimit-* headers. Missing/malformed headers: no-op."""
+        try:
+            limit = int(headers["x-ratelimit-limit"])
+            used = int(headers["x-ratelimit-used"])
+            window = float(headers["x-ratelimit-window"])
+        except (KeyError, ValueError, TypeError):
+            return
+
+        self._limit = limit
+        self._used = used
+        self._window_seconds = window
+
+        try:
+            self._burst_limit = int(headers["x-ratelimit-burst-limit"])
+        except (KeyError, ValueError, TypeError):
+            pass
+
+        try:
+            self._burst_used = int(headers["x-ratelimit-burst-used"])
+        except (KeyError, ValueError, TypeError):
+            pass
+
+    @property
+    def utilization(self) -> float:
+        """used / limit, 0.0 if no data yet."""
+        if self._limit == 0:
+            return 0.0
+        return self._used / self._limit
+
+    @property
+    def remaining(self) -> int:
+        """limit - used, 0 if no data yet."""
+        if self._limit == 0:
+            return 0
+        return max(0, self._limit - self._used)
+
+    def suggested_delay(self) -> float:
+        """Inter-request delay in seconds.
+
+        - Under 80% utilization: 0.0
+        - 80-100%: window_seconds / remaining (spread remaining budget evenly)
+        - At limit (remaining=0): window_seconds (wait for reset)
+        - No data yet (limit=0): 0.0
+        """
+        if self._limit == 0:
+            return 0.0
+        if self.utilization < _UTILIZATION_THRESHOLD:
+            return 0.0
+        remaining = self.remaining
+        if remaining == 0:
+            return self._window_seconds
+        return self._window_seconds / remaining
+
 
 async def fetch_with_retry(
     session: aiohttp.ClientSession,
@@ -18,6 +85,7 @@ async def fetch_with_retry(
     *,
     max_retries: int = 3,
     base_delay: float = 1.0,
+    budget: RateLimitBudget | None = None,
 ) -> aiohttp.ClientResponse:
     """Fetch a URL with retry on 429/5xx, respecting Retry-After headers.
 
@@ -26,6 +94,15 @@ async def fetch_with_retry(
     """
     request_timeout = aiohttp.ClientTimeout(total=30)
     for attempt in range(max_retries + 1):
+        if budget is not None:
+            delay = budget.suggested_delay()
+            if delay > 0:
+                _LOGGER.info(
+                    "Rate limit pacing: sleeping %.2fs before request (utilization %.0f%%)",
+                    delay, budget.utilization * 100,
+                )
+                await asyncio.sleep(delay)
+
         try:
             resp = await session.get(url, timeout=request_timeout)
         except (asyncio.TimeoutError, aiohttp.ServerTimeoutError):
@@ -39,6 +116,9 @@ async def fetch_with_retry(
                 continue
             _LOGGER.warning("All %d retries exhausted (timeout) for %s", max_retries, url)
             raise
+
+        if budget is not None:
+            budget.update_from_headers(resp.headers)
 
         if resp.status == 429:
             if attempt < max_retries:

--- a/custom_components/rain_incoming/providers/rainviewer.py
+++ b/custom_components/rain_incoming/providers/rainviewer.py
@@ -10,7 +10,7 @@ import numpy as np
 from PIL import Image
 
 from .base import BoundingBox, RadarFrame, RadarProvider
-from ..http_retry import fetch_with_retry
+from ..http_retry import RateLimitBudget, fetch_with_retry
 from ..radar.geo import lat_lon_to_tile
 
 import os
@@ -157,6 +157,7 @@ class RainViewerFrame(RadarFrame):
         width: int,
         height: int,
         session: aiohttp.ClientSession,
+        budget: RateLimitBudget | None = None,
     ) -> np.ndarray:
         """Fetch tiles covering bounds, stitch, and resample to (height, width)."""
         cx, cy = lat_lon_to_tile(
@@ -199,7 +200,7 @@ class RainViewerFrame(RadarFrame):
                 f"{TILE_BASE_URL}{self._path}"
                 f"/{TILE_SIZE}/{self._zoom}/{tx}/{ty}/{self._colour_scheme}/0.png"
             )
-            resp = await fetch_with_retry(session, url)
+            resp = await fetch_with_retry(session, url, budget=budget)
             tile_bytes = await resp.read()
 
             tile_arr = _tile_to_intensity_array(tile_bytes)

--- a/tests/integration/test_coordinator_frame_cache.py
+++ b/tests/integration/test_coordinator_frame_cache.py
@@ -68,7 +68,7 @@ def _patch_frame_fetch_succeeds(frame: RainViewerFrame, fetch_log: list[str] | N
     The fake stores bounds + size exactly as the coordinator will pass them, so
     get_intensity_grid() cache-hits when the coordinator calls it later.
     """
-    async def _fake_fetch(bounds, width, height, session):
+    async def _fake_fetch(bounds, width, height, session, budget=None):
         if fetch_log is not None:
             fetch_log.append(frame.path)
         frame._cached_grid = np.full((height, width), 0.5, dtype=np.float32)
@@ -85,7 +85,7 @@ def _patch_frame_fetch_fails(frame: RainViewerFrame, fetch_log: list[str] | None
     _cached_grid stays None. The coordinator's _fetch_frame() swallows the
     exception and logs a warning.
     """
-    async def _fake_fetch(bounds, width, height, session):
+    async def _fake_fetch(bounds, width, height, session, budget=None):
         if fetch_log is not None:
             fetch_log.append(frame.path)
         raise RuntimeError("simulated fetch failure")

--- a/tests/unit/test_coordinator_rate_limit.py
+++ b/tests/unit/test_coordinator_rate_limit.py
@@ -67,7 +67,7 @@ def _patch_frame_fetch_succeeds(frame: RainViewerFrame, grid: np.ndarray | None 
     so get_intensity_grid will return the cached grid (not zeros) when called
     with those same bounds.
     """
-    async def _fake_fetch(bounds, width, height, session):
+    async def _fake_fetch(bounds, width, height, session, budget=None):
         # Use the actual bounds/size the coordinator will later call get_intensity_grid
         # with, so the cache hit succeeds.
         g = grid if grid is not None else np.full((height, width), 0.5, dtype=np.float32)
@@ -80,7 +80,7 @@ def _patch_frame_fetch_succeeds(frame: RainViewerFrame, grid: np.ndarray | None 
 
 def _patch_frame_fetch_raises_429(frame: RainViewerFrame):
     """Patch a frame's _fetch_stitched_grid to raise a 429 error."""
-    async def _fake_fetch(bounds, width, height, session):
+    async def _fake_fetch(bounds, width, height, session, budget=None):
         raise _make_429_error()
 
     frame._fetch_stitched_grid = _fake_fetch

--- a/tests/unit/test_http_retry.py
+++ b/tests/unit/test_http_retry.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import aiohttp
 import pytest
 
-from custom_components.rain_incoming.http_retry import fetch_with_retry
+from custom_components.rain_incoming.http_retry import RateLimitBudget, fetch_with_retry
 
 
 def _make_response(status: int, headers: dict | None = None) -> MagicMock:
@@ -184,3 +184,133 @@ class TestFetchWithRetry:
         results = await asyncio.gather(*tasks)
         assert len(results) == 5
         assert max_concurrent <= 2
+
+
+class TestRateLimitBudget:
+    """Tests for RateLimitBudget."""
+
+    def test_rate_limit_budget_no_delay_under_80_percent(self) -> None:
+        budget = RateLimitBudget()
+        budget.update_from_headers({
+            "x-ratelimit-limit": "500",
+            "x-ratelimit-used": "350",
+            "x-ratelimit-window": "60",
+            "x-ratelimit-burst-limit": "300",
+            "x-ratelimit-burst-used": "200",
+        })
+        # 350/500 = 70%, under 80% threshold
+        assert budget.suggested_delay() == 0.0
+
+    def test_rate_limit_budget_delay_above_80_percent(self) -> None:
+        budget = RateLimitBudget()
+        budget.update_from_headers({
+            "x-ratelimit-limit": "500",
+            "x-ratelimit-used": "450",
+            "x-ratelimit-window": "60",
+            "x-ratelimit-burst-limit": "300",
+            "x-ratelimit-burst-used": "250",
+        })
+        # 450/500 = 90%, remaining=50, delay = 60/50 = 1.2s
+        delay = budget.suggested_delay()
+        assert delay > 0.0
+        assert delay == pytest.approx(60.0 / 50, rel=1e-6)
+
+    def test_rate_limit_budget_full_window_delay_at_limit(self) -> None:
+        budget = RateLimitBudget()
+        budget.update_from_headers({
+            "x-ratelimit-limit": "500",
+            "x-ratelimit-used": "500",
+            "x-ratelimit-window": "60",
+            "x-ratelimit-burst-limit": "300",
+            "x-ratelimit-burst-used": "300",
+        })
+        # remaining=0, delay = window_seconds
+        assert budget.suggested_delay() == 60.0
+
+    def test_rate_limit_budget_no_delay_without_data(self) -> None:
+        budget = RateLimitBudget()
+        # No headers read yet - limit=0, should return 0.0
+        assert budget.suggested_delay() == 0.0
+
+    def test_rate_limit_budget_update_from_headers_parses_correctly(self) -> None:
+        budget = RateLimitBudget()
+        budget.update_from_headers({
+            "x-ratelimit-limit": "500",
+            "x-ratelimit-used": "123",
+            "x-ratelimit-window": "60",
+            "x-ratelimit-burst-limit": "300",
+            "x-ratelimit-burst-used": "45",
+        })
+        assert budget.utilization == pytest.approx(123 / 500, rel=1e-6)
+        assert budget.remaining == 500 - 123
+
+    def test_rate_limit_budget_handles_missing_headers_gracefully(self) -> None:
+        budget = RateLimitBudget()
+        # Should not raise, and should return 0.0 with no data
+        budget.update_from_headers({})
+        assert budget.suggested_delay() == 0.0
+
+    def test_rate_limit_budget_handles_malformed_headers(self) -> None:
+        budget = RateLimitBudget()
+        # Non-numeric value should not raise, should be no-op
+        budget.update_from_headers({"x-ratelimit-limit": "notanumber"})
+        assert budget.suggested_delay() == 0.0
+
+    @pytest.mark.asyncio
+    async def test_fetch_with_retry_updates_budget_from_response(self) -> None:
+        session = AsyncMock(spec=aiohttp.ClientSession)
+        ok_resp = _make_response(200, headers={
+            "x-ratelimit-limit": "500",
+            "x-ratelimit-used": "100",
+            "x-ratelimit-window": "60",
+            "x-ratelimit-burst-limit": "300",
+            "x-ratelimit-burst-used": "80",
+        })
+        session.get = AsyncMock(return_value=ok_resp)
+
+        budget = RateLimitBudget()
+        assert budget.utilization == 0.0
+
+        await fetch_with_retry(session, "http://example.com/test", budget=budget)
+
+        assert budget.utilization > 0.0
+
+    @pytest.mark.asyncio
+    async def test_fetch_with_retry_adds_delay_when_suggested(self) -> None:
+        session = AsyncMock(spec=aiohttp.ClientSession)
+        ok_resp = _make_response(200)
+        session.get = AsyncMock(return_value=ok_resp)
+
+        budget = RateLimitBudget()
+        # Pre-load budget to >80% utilization so it suggests a delay
+        budget.update_from_headers({
+            "x-ratelimit-limit": "500",
+            "x-ratelimit-used": "460",
+            "x-ratelimit-window": "60",
+            "x-ratelimit-burst-limit": "300",
+            "x-ratelimit-burst-used": "280",
+        })
+        assert budget.suggested_delay() > 0.0
+
+        sleep_delays = []
+
+        async def mock_sleep(delay):
+            sleep_delays.append(delay)
+
+        with patch("custom_components.rain_incoming.http_retry.asyncio.sleep", side_effect=mock_sleep):
+            await fetch_with_retry(session, "http://example.com/test", budget=budget)
+
+        # Should have slept at least once before the request due to budget
+        assert len(sleep_delays) >= 1
+        assert sleep_delays[0] > 0.0
+
+    @pytest.mark.asyncio
+    async def test_fetch_with_retry_without_budget_unchanged(self) -> None:
+        session = AsyncMock(spec=aiohttp.ClientSession)
+        ok_resp = _make_response(200)
+        session.get = AsyncMock(return_value=ok_resp)
+
+        # Without budget, should work exactly as before - no extra behavior
+        result = await fetch_with_retry(session, "http://example.com/test")
+        assert result is ok_resp
+        assert session.get.call_count == 1


### PR DESCRIPTION
## Summary

- Adds `RateLimitBudget` class in `http_retry.py` that tracks `x-ratelimit-limit/used/window/burst-*` response headers from RainViewer tile responses
- Wires it into `fetch_with_retry` - updates budget after every response, adds proactive inter-request delay when >80% of the window budget is consumed (`window_seconds / remaining`)
- Threads the budget through `_fetch_stitched_grid` and the coordinator (one shared budget per coordinator instance)
- Pacing activates at INFO log level so it's visible without debug noise
- The existing 429 + Retry-After backstop in `fetch_with_retry` is unchanged - this is a proactive layer that sits above it

10 new unit tests covering `RateLimitBudget` behavior (no delay under 80%, proportional delay above, graceful handling of missing/malformed headers) and `fetch_with_retry` integration (budget updates from headers, delay applied when suggested).

## Test plan

- [x] `python -m pytest tests/unit/ -q` → 308 passed
- [ ] Smoke test against real RainViewer after merge (confirm no pacing delay at normal load)

Closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)