### PR TITLE
fix: replace deprecated asyncio.get_event_loop().run_until_complete() in test_attribution.py

### DIFF
--- a/tests/unit/radar/test_attribution.py
+++ b/tests/unit/radar/test_attribution.py
@@ -472,7 +472,7 @@ def test_render_composite_uses_passed_style_for_attribution():
         "custom_components.rain_incoming.radar.composite._draw_attribution",
         side_effect=_capture_draw_attribution,
     ):
-        asyncio.get_event_loop().run_until_complete(
+        asyncio.run(
             render_composite(
                 lat=-33.7,
                 lon=151.2,


### PR DESCRIPTION
## Summary

- Replaces `asyncio.get_event_loop().run_until_complete()` with `asyncio.run()` in `test_render_composite_uses_passed_style_for_attribution`
- `asyncio.get_event_loop()` is deprecated in Python 3.10+ when no running loop exists

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)