### PR TITLE
refactor(tests): decouple test_coordinator_rate_limit from internal state

### DIFF
--- a/tests/unit/test_coordinator_rate_limit.py
+++ b/tests/unit/test_coordinator_rate_limit.py
@@ -176,59 +176,6 @@ async def test_partial_rate_limit_does_not_raise_update_failed(hass: HomeAssista
     assert isinstance(result, DetectionResult)
 
 
-@pytest.mark.asyncio
-async def test_partial_rate_limit_failed_frames_contribute_zero_grids(hass: HomeAssistant):
-    """Frames that 429'd return zeros from get_intensity_grid.
-
-    This verifies the coordinator's documented contract: failed frames leave
-    _cached_grid as None, so get_intensity_grid returns zeros. The all-zero
-    check only fires when EVERY frame is zero, not just some.
-    """
-    entry = _make_entry()
-    coordinator = RainDetectorCoordinator(hass, entry)
-
-    base_ts = 1_700_000_000
-    frames = [_make_frame(base_ts + i * 600) for i in range(3)]
-    _patch_frame_fetch_succeeds(frames[0])
-    _patch_frame_fetch_raises_429(frames[1])
-    _patch_frame_fetch_succeeds(frames[2])
-
-    captured_grids: list[list[np.ndarray]] = []
-
-    def _capture_detect(**kwargs):
-        # Grab the grids the coordinator computed - these are passed implicitly
-        # via frames, so we check which frames have non-zero caches
-        return EMPTY_RESULT
-
-    mock_session = MagicMock()
-
-    with (
-        patch.object(coordinator._provider, "get_frames", new=AsyncMock(return_value=frames)),
-        patch(
-            "custom_components.rain_incoming.coordinator.async_get_clientsession",
-            return_value=mock_session,
-        ),
-        patch(
-            "custom_components.rain_incoming.coordinator.detect",
-            return_value=EMPTY_RESULT,
-        ),
-    ):
-        await coordinator._async_update_data()
-
-    # Frames 0 and 2 should have been populated; frame 1 (429) should have no cache
-    # Inspect _cached_grid directly - the coordinator's bounds are internal, but the
-    # cache is set (or not) by our fake _fetch_stitched_grid.
-    assert frames[0]._cached_grid is not None and np.count_nonzero(frames[0]._cached_grid) > 0, (
-        "Frame 0 succeeded - its cached grid should be non-zero"
-    )
-    assert frames[1]._cached_grid is None, (
-        "Frame 1 got 429 - its cached grid should be None (fetch never completed)"
-    )
-    assert frames[2]._cached_grid is not None and np.count_nonzero(frames[2]._cached_grid) > 0, (
-        "Frame 2 succeeded - its cached grid should be non-zero"
-    )
-
-
 # ---------------------------------------------------------------------------
 # Test 2: All fetches fail - total rate limit
 # ---------------------------------------------------------------------------
@@ -393,10 +340,6 @@ async def test_recovery_after_total_rate_limit(hass: HomeAssistant):
     ):
         with pytest.raises(UpdateFailed):
             await coordinator._async_update_data()
-
-    # Poll 1 fails at the tile-fetch level (not via _fetch_with_backoff), so the
-    # backoff counter must remain untouched at its initial value of zero.
-    assert coordinator._consecutive_failures == 0
 
     # --- Poll 2: full recovery ---
     frames_poll2 = [_make_frame(base_ts + (i + 4) * 600) for i in range(4)]

--- a/tests/unit/test_coordinator_rate_limit.py
+++ b/tests/unit/test_coordinator_rate_limit.py
@@ -176,6 +176,65 @@ async def test_partial_rate_limit_does_not_raise_update_failed(hass: HomeAssista
     assert isinstance(result, DetectionResult)
 
 
+@pytest.mark.asyncio
+async def test_partial_rate_limit_failed_frames_produce_zero_grids_for_detection(hass: HomeAssistant):
+    """Frames that 429 produce all-zero grids when the coordinator reads them for detection.
+
+    Verifies via get_intensity_grid (public method) that a failed frame contributes
+    zeros, not stale data from a prior fetch. The check is on what the coordinator
+    actually reads, not on internal cache state.
+    """
+    entry = _make_entry()
+    coordinator = RainDetectorCoordinator(hass, entry)
+
+    base_ts = 1_700_000_000
+    frames = [_make_frame(base_ts + i * 600) for i in range(3)]
+    _patch_frame_fetch_succeeds(frames[0])
+    _patch_frame_fetch_raises_429(frames[1])
+    _patch_frame_fetch_succeeds(frames[2])
+
+    # Spy on get_intensity_grid to capture what the coordinator reads per frame.
+    grids_read: dict[int, np.ndarray] = {}
+    for frame in frames:
+        original = frame.get_intensity_grid
+        def _make_spy(f, orig):
+            def spy(bounds, width, height):
+                result = orig(bounds, width, height)
+                grids_read[id(f)] = result
+                return result
+            return spy
+        frame.get_intensity_grid = _make_spy(frame, original)
+
+    mock_session = MagicMock()
+
+    with (
+        patch.object(coordinator._provider, "get_frames", new=AsyncMock(return_value=frames)),
+        patch(
+            "custom_components.rain_incoming.coordinator.async_get_clientsession",
+            return_value=mock_session,
+        ),
+        patch(
+            "custom_components.rain_incoming.coordinator.detect",
+            return_value=EMPTY_RESULT,
+        ),
+    ):
+        await coordinator._async_update_data()
+
+    assert id(frames[0]) in grids_read, "Frame 0: get_intensity_grid was never called"
+    assert id(frames[1]) in grids_read, "Frame 1: get_intensity_grid was never called"
+    assert id(frames[2]) in grids_read, "Frame 2: get_intensity_grid was never called"
+
+    assert np.any(grids_read[id(frames[0])] != 0), (
+        "Frame 0 succeeded - its grid should be non-zero"
+    )
+    assert np.all(grids_read[id(frames[1])] == 0), (
+        "Frame 1 got 429 - its grid should be all-zero (no stale data from a prior fetch)"
+    )
+    assert np.any(grids_read[id(frames[2])] != 0), (
+        "Frame 2 succeeded - its grid should be non-zero"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Test 2: All fetches fail - total rate limit
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes `test_partial_rate_limit_failed_frames_contribute_zero_grids` — it asserted on `frames[X]._cached_grid` (private attribute). The behavioral outcomes it was trying to guard (detect runs on partial failure, UpdateFailed on total) are covered by the surrounding tests.
- Removes `coordinator._consecutive_failures == 0` assertion from `test_recovery_after_total_rate_limit` — this is the coordinator's internal backoff counter. Recovery is already proven by poll 2 succeeding and `mock_detect2.called`.
- Tightens helper docstrings for clarity.

No production code changes. 406 tests pass.

Closes #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)