### PR TITLE
Add mutation testing scaffold, kill motion.py survivors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ env/
 .coverage
 htmlcov/
 .tox/
+.mutmut-cache
 
 # Type checking
 .mypy_cache/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,52 @@ Write a failing test, write minimum code to pass, refactor. That's it. If you're
 - **Golden data must exercise the full pipeline.** Run real captures through ALL transforms, filters, QC stages, and rendering steps - not just the detection algorithm in isolation.
 - **Don't change tests while refactoring.** If a test needs to change, stop and explain why before proceeding.
 
+## Mutation testing (mutmut)
+
+We use [mutmut](https://mutmut.readthedocs.io/) (v2.x) to verify test quality. It's a review tool, not a CI tool - run it when reviewing a module's test suite or after completing a batch of new tests.
+
+**When to run:**
+- During test reviews (like #77)
+- After completing a test suite for a new module
+- When you suspect tests are tautological (pass regardless of code changes)
+
+**Not for:** the TDD red-green-refactor cycle (too slow), or CI (too slow, flaky with in-place mutation).
+
+**How to run against a specific module:**
+
+```bash
+# Configure target in pyproject.toml [tool.mutmut], then:
+mutmut run
+
+# View survivors:
+mutmut results
+
+# Inspect a specific survivor:
+mutmut show <id>
+```
+
+The `[tool.mutmut]` section in `pyproject.toml` controls which file to mutate and which tests to run. Change `paths_to_mutate` and `runner` to target different modules. Example for motion.py:
+
+```toml
+[tool.mutmut]
+paths_to_mutate = "custom_components/rain_incoming/radar/motion.py"
+runner = "python -m pytest tests/unit/radar/test_motion.py -x -q --no-header --tb=line"
+tests_dir = "tests/unit/radar/"
+```
+
+**Goal: 100% kill rate.** Every surviving mutant is a test gap. When you find survivors, write tests that kill them before moving on. A clean mutation score means the bar is set and future survivors are immediately visible.
+
+**Equivalent mutants:** Some mutations don't change behavior (e.g. an `or` -> `and` on a guard clause where the loop body already handles the empty case). These can't be killed. Verify by applying the mutant (`mutmut apply <id>`) and confirming the behavior is genuinely identical, not just untested. Note equivalent mutants in test comments so future reviewers don't waste time.
+
+**Interpreting survivors:**
+- `** 2` -> `* 2` surviving in math = tests don't exercise enough numeric variety
+- `<=` -> `<` surviving = no boundary test at exact threshold
+- `continue` -> `break` surviving = loop body not tested with enough iterations
+- `or` -> `and` surviving = guard clause tested with insufficient input combinations (or equivalent mutant)
+- `return False` -> `return True` surviving = edge case input never tested
+
+**Important:** mutmut v2.x mutates files in-place. Don't pipe its verbose output into conversation windows - redirect to a file (`mutmut run > /tmp/mutmut.log 2>&1`) and inspect results with `mutmut results` and `mutmut show <id>`.
+
 ## Browser tests (Playwright)
 
 Browser tests are not unit tests. Don't write them like unit tests - guessing selectors, running, fixing, repeating. That's how flaky tests are born.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ tests_dir = "tests/unit/radar/"
 
 **Goal: 100% kill rate.** Every surviving mutant is a test gap. When you find survivors, write tests that kill them before moving on. A clean mutation score means the bar is set and future survivors are immediately visible.
 
-**Equivalent mutants:** Some mutations don't change behavior (e.g. an `or` -> `and` on a guard clause where the loop body already handles the empty case). These can't be killed. Verify by applying the mutant (`mutmut apply <id>`) and confirming the behavior is genuinely identical, not just untested. Note equivalent mutants in test comments so future reviewers don't waste time.
+**Equivalent mutants:** Some mutations don't change behavior (e.g. an `or` -> `and` on a guard clause where the loop body already handles the empty case). These can't be killed. Verify by applying the mutant (`mutmut apply <id>`) and confirming the behavior is genuinely identical, not just untested. Mark them in production code with `# pragma: no mutate (reason)` so they're skipped in future runs, and note them in test comments so future reviewers don't waste time.
 
 **Interpreting survivors:**
 - `** 2` -> `* 2` surviving in math = tests don't exercise enough numeric variety

--- a/custom_components/rain_incoming/radar/motion.py
+++ b/custom_components/rain_incoming/radar/motion.py
@@ -31,7 +31,7 @@ def match_cells_across_frames(
     Returns a list of (t0_label, t1_label) pairs.
     Each t1 cell is matched at most once (to the closest t0 cell within max_distance).
     """
-    if not centroids_t0 or not centroids_t1:
+    if not centroids_t0 or not centroids_t1:  # pragma: no mutate (equivalent - loop handles empty)
         return []
 
     # Build all candidate pairs with distances

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dev = [
     "aiohttp>=3.9",
     "aioresponses>=0.7",
     "playwright>=1.40",
+    "mutmut>=2.5,<3",
 ]
 
 [tool.setuptools.packages.find]
@@ -35,3 +36,8 @@ pythonpath = ["."]
 [tool.coverage.run]
 source = ["custom_components/rain_incoming"]
 omit = ["tests/*"]
+
+[tool.mutmut]
+paths_to_mutate = "custom_components/rain_incoming/radar/motion.py"
+runner = "python -m pytest tests/unit/radar/test_motion.py -x -q --no-header --tb=line"
+tests_dir = "tests/unit/radar/"

--- a/tests/unit/radar/test_motion.py
+++ b/tests/unit/radar/test_motion.py
@@ -82,6 +82,91 @@ class TestMatchCellsAcrossFrames:
         t1_labels = [m[1] for m in matches]
         assert len(set(t1_labels)) == len(t1_labels), "t1 cell matched more than once"
 
+    # -- mutmut survivors below --
+
+    def test_one_empty_dict_returns_no_matches(self):
+        """Mutant #15: `or` -> `and` in the empty-guard clause.
+        EQUIVALENT MUTANT - the nested loop over an empty dict produces no
+        candidates regardless, so the guard is an optimization not a behavior.
+        This test documents the expected behavior but cannot kill the mutant."""
+        t0 = {1: (0.0, 0.0)}
+        t1: dict[int, tuple[float, float]] = {}
+        assert match_cells_across_frames(t0, t1, max_distance=10.0) == []
+        assert match_cells_across_frames({}, {1: (0.0, 0.0)}, max_distance=10.0) == []
+
+    def test_distance_calculation_uses_squared_components(self):
+        """Kill mutants #18-23: `** 2` -> `* 2` or `** 3` in distance calc.
+        Place cells 5px apart on one axis. Euclidean = 5.0.
+        With `* 2` the distance would be sqrt(10) ~ 3.16 (wrong match).
+        With `** 3` the distance would be sqrt(125) ~ 11.18 (wrong reject).
+        Use max_distance=5.0 so only the correct `** 2` produces a match."""
+        t0 = {1: (0.0, 0.0)}
+        t1 = {1: (5.0, 0.0)}
+        # Exact Euclidean distance = 5.0, so max_distance=5.0 should match (<=)
+        matches = match_cells_across_frames(t0, t1, max_distance=5.0)
+        assert len(matches) == 1, "5px cell must match at max_distance=5.0"
+
+        # Now test the column axis too (kills the (c1-c0) mutations)
+        t0_col = {1: (0.0, 0.0)}
+        t1_col = {1: (0.0, 5.0)}
+        matches_col = match_cells_across_frames(t0_col, t1_col, max_distance=5.0)
+        assert len(matches_col) == 1, "5px column cell must match at max_distance=5.0"
+
+        # And a case that should NOT match: just beyond 5.0
+        t1_far = {1: (5.1, 0.0)}
+        matches_far = match_cells_across_frames(t0, t1_far, max_distance=5.0)
+        assert matches_far == [], "5.1px cell must not match at max_distance=5.0"
+
+    def test_distance_column_axis_tight_threshold(self):
+        """Kill mutant #22: `(c1-c0) ** 2` -> `(c1-c0) * 2` in column distance.
+        Cell 4px apart on column axis only. Correct: sqrt(16) = 4.0.
+        With `* 2`: sqrt(8) = 2.83. Use max_distance=3.5 so the correct distance
+        exceeds it (no match) but the mutated distance fits (wrong match)."""
+        t0 = {1: (0.0, 0.0)}
+        t1 = {1: (0.0, 4.0)}
+        matches = match_cells_across_frames(t0, t1, max_distance=3.5)
+        assert matches == [], "4px column distance must exceed max_distance=3.5"
+
+    def test_boundary_distance_is_inclusive(self):
+        """Kill mutant #25: `<=` -> `<` in distance comparison.
+        Cell at exactly max_distance must be included."""
+        t0 = {1: (0.0, 0.0)}
+        t1 = {1: (3.0, 4.0)}  # distance = exactly 5.0
+        matches = match_cells_across_frames(t0, t1, max_distance=5.0)
+        assert len(matches) == 1, "Cell at exactly max_distance must match (<=, not <)"
+
+    def test_continue_past_claimed_cells_to_find_later_matches(self):
+        """Kill mutant #32: `continue` -> `break` in the matching loop.
+        Three cells: the closest pair claims t1[10], then the loop must
+        CONTINUE past the claimed entry to find the next valid match for t0[2].
+        With `break`, the loop exits early and t0[2] never gets matched."""
+        t0 = {1: (0.0, 0.0), 2: (10.0, 0.0)}
+        t1 = {10: (0.5, 0.0), 20: (10.5, 0.0)}
+        # Sorted candidates: (0.5, 1, 10), (0.5, 2, 20), (10.5, 1, 20), (9.5, 2, 10)
+        # Actually let me recalculate...
+        # (1->10): dist = 0.5  (1->20): dist = 10.5  (2->10): dist = 9.5  (2->20): dist = 0.5
+        # Sorted: (0.5, 1, 10), (0.5, 2, 20), (9.5, 2, 10), (10.5, 1, 20)
+        # First match: (1, 10). Then (2, 20) is next - both unclaimed, match.
+        # With break: after (1, 10) matches, loop sees (2, 20) which is unclaimed... hmm.
+        # Need a case where a claimed entry appears BETWEEN two valid matches.
+        # Let me restructure: three t0 cells, two t1 cells, with an intermediate
+        # distance that blocks.
+        t0 = {1: (0.0, 0.0), 2: (1.0, 0.0), 3: (20.0, 0.0)}
+        t1 = {10: (0.5, 0.0), 20: (20.5, 0.0)}
+        # Candidates sorted by distance:
+        # (0.5, 1, 10), (0.5, 2, 10)... wait, t1[10] is at 0.5 from t0[1] and 0.5 from t0[2]
+        # Actually: dist(1,10)=0.5, dist(2,10)=0.5, dist(3,20)=0.5, dist(1,20)=20.5, dist(2,20)=19.5, dist(3,10)=19.5
+        # Sorted: (0.5, 1, 10), (0.5, 2, 10), (0.5, 3, 20), (19.5, 2, 20), (19.5, 3, 10), (20.5, 1, 20)
+        # Match (1, 10). Next: (2, 10) - t1[10] claimed, CONTINUE. Next: (3, 20) - unclaimed, match.
+        # With BREAK at (2, 10): loop exits, (3, 20) never checked. Only 1 match instead of 2.
+        matches = match_cells_across_frames(t0, t1, max_distance=25.0)
+        matched_t0_labels = sorted(m[0] for m in matches)
+        assert len(matches) == 2, (
+            f"Expected 2 matches (skipping claimed t1 cell), got {len(matches)}: {matches}"
+        )
+        assert 1 in matched_t0_labels
+        assert 3 in matched_t0_labels
+
 
 class TestEstimateVelocity:
     def test_stationary_cell_has_zero_velocity(self):
@@ -132,3 +217,61 @@ class TestIsDirectionallyCoherent:
         # Stationary noise has no direction - not coherent movement
         velocities = [(0.0, 0.0), (0.0, 0.0)]
         assert not is_directionally_coherent(velocities, max_angular_variance=0.5)
+
+    # -- mutmut survivors below --
+
+    def test_empty_velocities_returns_false(self):
+        """Kill mutant #44: `return False` -> `return True` for empty input."""
+        assert not is_directionally_coherent([], max_angular_variance=0.5)
+
+    def test_circular_variance_math_coherent_case(self):
+        """Kill mutants #62, #65: `** 2` -> `** 3` in R calculation.
+
+        Two velocities at ~45 degrees apart. Correct circular variance ~ 0.076.
+        With `** 3`, R changes enough to flip the result.
+
+        Velocities: (1, 0) = 90 deg and (0.7, 0.7) ~ 45 deg.
+        Mean resultant R ~ 0.924, circular_variance ~ 0.076.
+        With max_angular_variance = 0.1, this should be coherent."""
+        velocities = [(1.0, 0.0), (0.7, 0.7)]
+        assert is_directionally_coherent(velocities, max_angular_variance=0.1), (
+            "Two velocities ~45 degrees apart should be coherent at variance=0.1"
+        )
+
+    def test_circular_variance_incoherent_rejects_inflated_r(self):
+        """Kill mutants #57, #61: `/ len` -> `* len` and `** 2` -> `* 2` in R calc.
+
+        Two velocities ~117 degrees apart. Correct variance ~ 0.475 (incoherent).
+        Mutations that inflate sin_mean (multiplying by len instead of dividing,
+        or using `* 2` instead of `** 2`) artificially boost R, making variance
+        negative - wrongly appearing coherent.
+
+        With max_angular_variance = 0.4, this MUST be incoherent."""
+        velocities = [(0.0, 1.0), (1.0, -0.5)]
+        assert not is_directionally_coherent(velocities, max_angular_variance=0.4), (
+            "Two velocities ~117 degrees apart must be incoherent at variance=0.4"
+        )
+
+    def test_circular_variance_boundary_rejects_at_threshold(self):
+        """Kill mutant #70: `<=` -> `<` in threshold comparison.
+
+        Construct velocities where circular_variance == max_angular_variance exactly.
+        The `<=` operator means this should return True; `<` would return False.
+
+        Two velocities pointing in directions that produce a known circular variance.
+        We compute the exact variance and use it as the threshold."""
+        # Two velocities: east (0, 1) and slightly north-of-east (0.2, 1.0)
+        velocities = [(0.0, 1.0), (0.2, 1.0)]
+
+        # Compute expected circular variance to use as exact threshold
+        import math
+        angles = [math.atan2(vy, vx) for vy, vx in velocities]
+        sin_mean = sum(math.sin(a) for a in angles) / len(angles)
+        cos_mean = sum(math.cos(a) for a in angles) / len(angles)
+        r = math.sqrt(sin_mean ** 2 + cos_mean ** 2)
+        exact_variance = 1.0 - r
+
+        # At exactly the threshold, <= should return True
+        assert is_directionally_coherent(velocities, max_angular_variance=exact_variance), (
+            f"Circular variance {exact_variance:.6f} at exact threshold must be coherent (<=)"
+        )


### PR DESCRIPTION
## Summary
- Sets up mutmut v2.x for test quality review (not CI - manual review tool)
- Ran against `radar/motion.py`: 70 mutants, 12/13 killed, 1 equivalent mutant documented with pragma in code
- Adds 9 targeted tests to `test_motion.py` that kill surviving mutants in distance calculation, cell matching loop, and circular variance math
- Documents mutation testing workflow in CLAUDE.md (when to run, how to interpret, equivalent mutants)

## Mutant kill summary
| Mutant | Mutation | Status |
|--------|----------|--------|
| #15 | `or` -> `and` in empty guard | Equivalent (loop handles empty case) |
| #18-23 | `** 2` -> `* 2`/`** 3` in distance | Killed |
| #25 | `<=` -> `<` in distance boundary | Killed |
| #32 | `continue` -> `break` in match loop | Killed |
| #44 | `return False` -> `return True` for empty input | Killed |
| #57-65 | Math mutations in circular variance | Killed |
| #70 | `<=` -> `<` in variance threshold | Killed |

Closes #77

## Test plan
- [x] All 29 motion tests pass
- [x] Full unit + integration suite passes (416 tests)
- [x] mutmut run confirms no survivors

🤖 Generated with [Claude Code](https://claude.com/claude-code)