### PR TITLE
Refactor: address SonarCloud findings

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -26,6 +26,6 @@ jobs:
         run: pytest tests/unit/ tests/integration/ --cov=custom_components/rain_incoming --cov-report=xml:coverage.xml -q
 
       - name: SonarCloud Scan
-        uses: SonarSource/sonarqube-scan-action@v6
+        uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/custom_components/rain_incoming/http_retry.py
+++ b/custom_components/rain_incoming/http_retry.py
@@ -79,6 +79,35 @@ class RateLimitBudget:
         return self._window_seconds / remaining
 
 
+def _get_retry_delay(
+    resp: aiohttp.ClientResponse,
+    attempt: int,
+    base_delay: float,
+) -> float:
+    """Compute the retry delay for a retryable response.
+
+    For 429 responses, respects the Retry-After header if present and numeric.
+    For all other statuses, uses exponential backoff.
+    """
+    delay = base_delay * (2 ** attempt)
+    if resp.status == 429:
+        retry_after = resp.headers.get("Retry-After")
+        if retry_after:
+            try:
+                delay = float(retry_after)
+            except ValueError:
+                _LOGGER.debug(
+                    "Non-numeric Retry-After header '%s', using exponential backoff",
+                    retry_after,
+                )
+    return delay
+
+
+def _is_retryable_status(status: int) -> bool:
+    """Return True for HTTP statuses that should trigger a retry."""
+    return status == 429 or status >= 500
+
+
 async def fetch_with_retry(
     session: aiohttp.ClientSession,
     url: str,
@@ -124,42 +153,17 @@ async def fetch_with_retry(
         if budget is not None:
             budget.update_from_headers(resp.headers)
 
-        if resp.status == 429:
+        if _is_retryable_status(resp.status):
             if attempt < max_retries:
-                retry_after = resp.headers.get("Retry-After")
-                delay = base_delay * (2 ** attempt)
-                if retry_after:
-                    try:
-                        delay = float(retry_after)
-                    except ValueError:
-                        _LOGGER.debug(
-                            "Non-numeric Retry-After header '%s', using exponential backoff",
-                            retry_after,
-                        )
+                delay = _get_retry_delay(resp, attempt, base_delay)
                 _LOGGER.warning(
-                    "Rate limited (429) on %s, retrying in %.1fs (attempt %d/%d)",
-                    url, delay, attempt + 1, max_retries,
-                )
-                resp.release()
-                await asyncio.sleep(delay)
-                continue
-            # All retries exhausted on 429
-            _LOGGER.warning(
-                "All %d retries exhausted (429) for %s", max_retries, url,
-            )
-            resp.raise_for_status()
-
-        if resp.status >= 500:
-            if attempt < max_retries:
-                delay = base_delay * (2 ** attempt)
-                _LOGGER.warning(
-                    "Server error (%d) on %s, retrying in %.1fs (attempt %d/%d)",
+                    "%s (%d) on %s, retrying in %.1fs (attempt %d/%d)",
+                    "Rate limited" if resp.status == 429 else "Server error",
                     resp.status, url, delay, attempt + 1, max_retries,
                 )
                 resp.release()
                 await asyncio.sleep(delay)
                 continue
-            # All retries exhausted on 5xx
             _LOGGER.warning(
                 "All %d retries exhausted (%d) for %s",
                 max_retries, resp.status, url,

--- a/custom_components/rain_incoming/image.py
+++ b/custom_components/rain_incoming/image.py
@@ -163,9 +163,11 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
         location_name = data.get(CONF_LOCATION_NAME) or None
         map_style = self.coordinator.map_style
 
+        log_location = location_name or "default location"
+
         _LOGGER.debug(
             "Radar %dkm: background render starting, %d frames for %s (style=%s)",
-            self._radius_km, len(frame_paths), location_name or "default location", map_style,
+            self._radius_km, len(frame_paths), log_location, map_style,
         )
 
         try:
@@ -196,12 +198,12 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
         except asyncio.TimeoutError:
             _LOGGER.warning(
                 "Radar %dkm: render timed out after %.0fs for %s; keeping previous cache or placeholder",
-                self._radius_km, _RENDER_TIMEOUT_SECONDS, location_name or "default location",
+                self._radius_km, _RENDER_TIMEOUT_SECONDS, log_location,
             )
         except Exception:
             _LOGGER.exception(
                 "Radar %dkm: render failed for %s",
-                self._radius_km, location_name or "default location",
+                self._radius_km, log_location,
             )
 
     async def async_added_to_hass(self) -> None:


### PR DESCRIPTION
## Summary
- Pin SonarCloud action to full SHA (security hotspot)
- Reduce cognitive complexity in `fetch_with_retry` by extracting `_get_retry_delay()` and `_is_retryable_status()` helpers
- Extract duplicated `"default location"` string in `image.py`

## Approach
Pure refactoring - no behavior changes, no test changes. All 428 existing tests pass unchanged.

## What's NOT in this PR
- `coordinator._async_update_data` (complexity 31) and `detector.detect` (complexity 31+) are deferred - these are orchestration functions that need more careful decomposition
- `config_flow.py` (complexity 17 vs limit 15) - standard HA config flow boilerplate, not worth refactoring
- Test-only issues (async keyword warnings, float equality) - harmless, addressed via SonarCloud exclusions

## Test plan
- [x] All 19 http_retry tests pass unchanged
- [x] Full suite passes (428 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)