### PR TITLE
C2: Make analysis tile prefetch concurrent

### DIFF
--- a/custom_components/rain_incoming/providers/rainviewer.py
+++ b/custom_components/rain_incoming/providers/rainviewer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 import math
 from datetime import datetime, timezone
@@ -274,16 +275,14 @@ class RainViewerProvider(RadarProvider):
         session,
         **kwargs,
     ) -> None:
-        """Pre-fetch stitched grids for all frames.
+        """Pre-fetch stitched grids for all frames concurrently.
 
-        Fetches each frame's tiles individually (C2 will add concurrency).
         Failures are logged as warnings and the frame is skipped - the
         coordinator checks _cached_grid to detect partial failures.
         """
         budget = kwargs.get("budget")
-        for frame in frames:
-            if not isinstance(frame, RainViewerFrame):
-                continue
+
+        async def _fetch_one(frame: RainViewerFrame) -> None:
             try:
                 await frame._fetch_stitched_grid(bounds, width, height, session, budget=budget)
             except aiohttp.ClientResponseError as e:
@@ -296,6 +295,10 @@ class RainViewerProvider(RadarProvider):
                     "Radar grid fetch failed: %s: %s for frame %s",
                     type(e).__name__, e, frame.timestamp,
                 )
+
+        rv_frames = [f for f in frames if isinstance(f, RainViewerFrame)]
+        if rv_frames:
+            await asyncio.gather(*[_fetch_one(f) for f in rv_frames])
 
     async def _fetch_manifest(self) -> dict:
         async with aiohttp.ClientSession() as session:

--- a/tests/unit/providers/test_rainviewer.py
+++ b/tests/unit/providers/test_rainviewer.py
@@ -181,6 +181,48 @@ class TestRainViewerProvider:
             with pytest.raises(ClientError):
                 await provider.get_frames(-33.701, 151.209, count=3)
 
+    @pytest.mark.asyncio
+    async def test_prefetch_frames_fetches_concurrently(self):
+        """prefetch_frames must fetch multiple frames concurrently, not sequentially.
+
+        Uses overlap detection: if max_concurrent > 1 during the fetch, the
+        frames were fetched in parallel.
+        """
+        import asyncio
+
+        provider = RainViewerProvider()
+        frames = [
+            RainViewerFrame(
+                timestamp=datetime(2026, 4, 10, 10, i * 10, tzinfo=timezone.utc),
+                path=f"/v2/radar/frame{i}",
+                zoom=7,
+                colour_scheme=2,
+            )
+            for i in range(3)
+        ]
+
+        concurrent_count = 0
+        max_concurrent = 0
+
+        original_fetch = RainViewerFrame._fetch_stitched_grid
+
+        async def tracking_fetch(self, bounds, width, height, session, budget=None):
+            nonlocal concurrent_count, max_concurrent
+            concurrent_count += 1
+            max_concurrent = max(max_concurrent, concurrent_count)
+            await asyncio.sleep(0.01)
+            concurrent_count -= 1
+
+        with patch.object(RainViewerFrame, "_fetch_stitched_grid", tracking_fetch):
+            await provider.prefetch_frames(
+                frames, FAKE_BOUNDS, 64, 64, MagicMock(),
+            )
+
+        assert max_concurrent > 1, (
+            f"Frames were fetched sequentially (max_concurrent={max_concurrent}). "
+            "prefetch_frames must use asyncio.gather or similar for concurrent fetches."
+        )
+
 
 # --- check_coverage tests ---
 


### PR DESCRIPTION
**Closes #96**
**Depends on:** PR #111 (C1) - merge that first

## Summary
- `prefetch_frames` now uses `asyncio.gather` to fetch all frames concurrently
- Previously sequential: 4 tiles x 30s timeout = up to 120s worst case
- Now concurrent: all frames fetched in parallel, ~1x latency

## TDD
- Test written first: `test_prefetch_frames_fetches_concurrently` uses overlap detection to verify max_concurrent > 1
- Confirmed RED before implementation, GREEN after

## Test plan
- [x] New concurrency test passes
- [x] Full suite passes (429 tests)