### PR TITLE
C5: Add cache cleanup on unload and bounded map tile cache

### DIFF
--- a/custom_components/rain_incoming/__init__.py
+++ b/custom_components/rain_incoming/__init__.py
@@ -91,4 +91,8 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
+        # Clear tile caches when the last entry is unloaded to free memory
+        if not hass.data[DOMAIN]:
+            from .radar.composite import clear_tile_caches
+            clear_tile_caches()
     return unload_ok

--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -39,13 +39,21 @@ _CROSSHAIR_LINE_LENGTH = 16
 _CROSSHAIR_LINE_GAP = 12
 
 # Module-level cache for static map tiles: (style, zoom, x, y) -> RGBA Image
+# Bounded to prevent unbounded memory growth (each tile ~256KB).
 _map_tile_cache: dict[tuple, Image.Image] = {}
+_MAP_CACHE_MAX = 200
 
 # Module-level cache for radar tiles: (frame_path, zoom, x, y, scheme) -> RGBA Image
 # The cache key includes frame_path, so stale data can never be served.
 # We cap size at 500 entries and evict the oldest half when exceeded.
 _radar_tile_cache: dict[tuple[str, int, int, int, int], Image.Image] = {}
 _RADAR_CACHE_MAX = 500
+
+
+def clear_tile_caches() -> None:
+    """Clear both tile caches. Called when the last config entry is unloaded."""
+    _map_tile_cache.clear()
+    _radar_tile_cache.clear()
 
 # Semaphore to limit concurrent tile fetches (shared across map + radar)
 _tile_semaphore: asyncio.Semaphore | None = None
@@ -65,6 +73,14 @@ def _evict_radar_cache_if_full() -> None:
         keys = list(_radar_tile_cache.keys())
         for k in keys[: len(keys) // 2]:
             del _radar_tile_cache[k]
+
+
+def _evict_map_cache_if_full() -> None:
+    """Evict oldest half of map tile cache when it exceeds the size limit."""
+    if len(_map_tile_cache) > _MAP_CACHE_MAX:
+        keys = list(_map_tile_cache.keys())
+        for k in keys[: len(keys) // 2]:
+            del _map_tile_cache[k]
 
 
 def km_per_pixel(lat: float, zoom: int) -> float:
@@ -244,6 +260,7 @@ async def _fetch_map_tile(
         from PIL import ImageEnhance
         tile = ImageEnhance.Color(tile).enhance(1.8)
 
+    _evict_map_cache_if_full()
     _map_tile_cache[cache_key] = tile  # type: ignore[index]
     return tile
 

--- a/tests/unit/radar/test_cache_cleanup.py
+++ b/tests/unit/radar/test_cache_cleanup.py
@@ -5,6 +5,7 @@ entries are unloaded, and the map cache must have a size limit.
 """
 from __future__ import annotations
 
+import pytest
 from PIL import Image
 
 from custom_components.rain_incoming.radar.composite import (
@@ -43,3 +44,55 @@ class TestMapCacheBounded:
         assert _MAP_CACHE_MAX <= 500, (
             f"Map cache limit {_MAP_CACHE_MAX} is too large - each tile is ~256KB"
         )
+
+    def test_map_cache_evicts_when_full(self):
+        """Filling the map cache past _MAP_CACHE_MAX must trigger eviction."""
+        from custom_components.rain_incoming.radar.composite import _evict_map_cache_if_full
+
+        _map_tile_cache.clear()
+        try:
+            tiny = Image.new("RGBA", (1, 1))
+            for i in range(_MAP_CACHE_MAX + 10):
+                _map_tile_cache[("style", 7, i, 0)] = tiny
+
+            assert len(_map_tile_cache) > _MAP_CACHE_MAX
+
+            _evict_map_cache_if_full()
+
+            assert len(_map_tile_cache) <= _MAP_CACHE_MAX, (
+                f"Map cache has {len(_map_tile_cache)} entries after eviction, "
+                f"expected <= {_MAP_CACHE_MAX}"
+            )
+        finally:
+            _map_tile_cache.clear()
+
+
+class TestUnloadClearsCaches:
+    """async_unload_entry must clear tile caches when the last entry is removed."""
+
+    @pytest.mark.asyncio
+    async def test_unload_last_entry_clears_caches(self):
+        from unittest.mock import AsyncMock, MagicMock, patch
+
+        from custom_components.rain_incoming import async_unload_entry
+        from custom_components.rain_incoming.const import DOMAIN
+
+        # Populate caches
+        _map_tile_cache[("test", 7, 1, 1)] = Image.new("RGBA", (1, 1))
+        _radar_tile_cache[("/v2/radar/x", 7, 1, 1, 2)] = Image.new("RGBA", (1, 1))
+
+        hass = MagicMock()
+        entry = MagicMock()
+        entry.entry_id = "last_entry"
+
+        coordinator = AsyncMock()
+        coordinator.async_save_clutter_map = AsyncMock()
+
+        # Simulate last entry: after pop, the domain dict is empty
+        hass.data = {DOMAIN: {entry.entry_id: coordinator}}
+        hass.config_entries.async_unload_platforms = AsyncMock(return_value=True)
+
+        await async_unload_entry(hass, entry)
+
+        assert len(_map_tile_cache) == 0, "Map cache must be cleared after last entry unload"
+        assert len(_radar_tile_cache) == 0, "Radar cache must be cleared after last entry unload"

--- a/tests/unit/radar/test_cache_cleanup.py
+++ b/tests/unit/radar/test_cache_cleanup.py
@@ -1,0 +1,45 @@
+"""Tests for tile cache cleanup and bounds.
+
+C5: Module-level tile caches in composite.py must be cleared when all
+entries are unloaded, and the map cache must have a size limit.
+"""
+from __future__ import annotations
+
+from PIL import Image
+
+from custom_components.rain_incoming.radar.composite import (
+    _map_tile_cache,
+    _radar_tile_cache,
+    _MAP_CACHE_MAX,
+    clear_tile_caches,
+)
+
+
+class TestClearTileCaches:
+    """clear_tile_caches must empty both module-level caches."""
+
+    def test_clears_both_caches(self):
+        # Populate caches with dummy data
+        _map_tile_cache[("test", 7, 10, 20)] = Image.new("RGBA", (1, 1))
+        _radar_tile_cache[("/v2/radar/x", 7, 10, 20, 2)] = Image.new("RGBA", (1, 1))
+
+        assert len(_map_tile_cache) > 0
+        assert len(_radar_tile_cache) > 0
+
+        clear_tile_caches()
+
+        assert len(_map_tile_cache) == 0, "Map cache must be empty after clear"
+        assert len(_radar_tile_cache) == 0, "Radar cache must be empty after clear"
+
+
+class TestMapCacheBounded:
+    """Map tile cache must have a size limit to prevent unbounded memory growth."""
+
+    def test_map_cache_max_is_defined(self):
+        assert _MAP_CACHE_MAX > 0, "Map cache must have a positive size limit"
+
+    def test_map_cache_max_is_reasonable(self):
+        # Each RGBA 256x256 tile is ~256KB. At 200 entries that's ~50MB.
+        assert _MAP_CACHE_MAX <= 500, (
+            f"Map cache limit {_MAP_CACHE_MAX} is too large - each tile is ~256KB"
+        )


### PR DESCRIPTION
**Closes #99**

## Summary
- Map tile cache now has `_MAP_CACHE_MAX=200` with FIFO eviction (matching radar cache pattern)
- New `clear_tile_caches()` function empties both caches
- `async_unload_entry` calls `clear_tile_caches()` when the last entry is unloaded

## Why
Module-level caches were never cleared (memory leak on integration reload) and the map cache grew unbounded. At ~256KB per tile, 200+ uncapped map tiles = significant memory.

## TDD
3 tests written first: cache clearing, constant existence, reasonable size limit.

## Test plan
- [x] 3 new cache tests pass
- [x] Full suite passes (431 tests)