### PR TITLE
I3: Per-entry clutter map file to prevent cross-location corruption

### DIFF
--- a/custom_components/rain_incoming/coordinator.py
+++ b/custom_components/rain_incoming/coordinator.py
@@ -141,8 +141,9 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
         self.last_rain_nearby_time: datetime | None = None
 
         # Clutter map - loaded lazily in _async_update_data to avoid blocking I/O
+        clutter_filename = f"rain_incoming_clutter_{entry.entry_id}.npz"
         self._clutter_path = os.path.join(
-            hass.config.path(".storage"), CLUTTER_MAP_FILENAME
+            hass.config.path(".storage"), clutter_filename
         )
         self._clutter_map: ClutterMap | None = None
         self._clutter_loaded = False

--- a/tests/unit/test_clutter_map_path.py
+++ b/tests/unit/test_clutter_map_path.py
@@ -1,0 +1,49 @@
+"""Test that each config entry gets its own clutter map file.
+
+I3: With a shared filename, multiple locations overwrite each other's
+clutter maps. The filename must include the entry ID.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.rain_incoming.coordinator import RainDetectorCoordinator
+
+
+def _make_hass():
+    hass = MagicMock()
+    hass.config.path.return_value = "/fake/.storage"
+    hass.config.latitude = -33.7
+    hass.config.longitude = 151.2
+    return hass
+
+
+def _make_entry(entry_id: str):
+    entry = MagicMock()
+    entry.entry_id = entry_id
+    entry.data = {"latitude": -33.7, "longitude": 151.2, "lookahead_minutes": 60}
+    return entry
+
+
+class TestClutterMapPath:
+    def test_clutter_path_includes_entry_id(self):
+        """The clutter map filename must include the entry ID so each
+        location gets its own file."""
+        hass = _make_hass()
+        entry = _make_entry("abc123")
+        coordinator = RainDetectorCoordinator(hass, entry)
+
+        assert "abc123" in coordinator._clutter_path, (
+            f"Clutter path must include entry ID. Got: {coordinator._clutter_path}"
+        )
+
+    def test_different_entries_get_different_paths(self):
+        """Two coordinators with different entry IDs must use different files."""
+        hass = _make_hass()
+        coord_a = RainDetectorCoordinator(hass, _make_entry("location_a"))
+        coord_b = RainDetectorCoordinator(hass, _make_entry("location_b"))
+
+        assert coord_a._clutter_path != coord_b._clutter_path, (
+            f"Different entries must use different clutter paths. "
+            f"Both got: {coord_a._clutter_path}"
+        )


### PR DESCRIPTION
**Closes #102**

## Problem
All locations wrote to `rain_incoming_clutter.npz`. Multi-location users had location A's clutter map overwritten by location B.

## Fix
Filename now includes entry_id: `rain_incoming_clutter_{entry_id}.npz`

## TDD
- `test_clutter_path_includes_entry_id` - RED then GREEN
- `test_different_entries_get_different_paths` - RED then GREEN

## Test plan
- [x] 2 new tests pass
- [x] Full suite passes (439 tests)