### PR TITLE
Batch minor cleanups: float equality, inline imports, private attr, default_factory

### DIFF
--- a/custom_components/rain_incoming/coordinator.py
+++ b/custom_components/rain_incoming/coordinator.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
+import os
 from datetime import datetime, timedelta, timezone
 
 import aiohttp
+import numpy as np
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_LATITUDE, CONF_LONGITUDE
@@ -76,7 +79,6 @@ CLUTTER_MATURITY_CYCLES = 72  # fully mature after ~12 hours
 
 def _build_analysis_tiles(lat: float, lon: float, zoom: int) -> list[tuple[int, int]]:
     """Return the 4 tile coordinates of the 2x2 block that best centres the location."""
-    import math
     from .radar.geo import lat_lon_to_tile
 
     cx, cy = lat_lon_to_tile(lat, lon, zoom)
@@ -139,7 +141,6 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
         self.last_rain_nearby_time: datetime | None = None
 
         # Clutter map - loaded lazily in _async_update_data to avoid blocking I/O
-        import os
         self._clutter_path = os.path.join(
             hass.config.path(".storage"), CLUTTER_MAP_FILENAME
         )
@@ -161,6 +162,11 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
             CONF_MAP_STYLE,
             self._entry.data.get(CONF_MAP_STYLE, "voyager"),
         )
+
+    @property
+    def consecutive_failures(self) -> int:
+        """Number of consecutive fetch failures (for diagnostics)."""
+        return self._consecutive_failures
 
     async def async_save_clutter_map(self) -> None:
         """Persist the clutter map to disk. Called on HA shutdown."""
@@ -267,7 +273,6 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
         # unavailable instead of a false "no rain". We check _cached_grid
         # (set by _fetch_stitched_grid on success) rather than grid content,
         # because all-zero grids are valid - they mean "no precipitation".
-        import numpy as np
         if frames and all(getattr(f, "_cached_grid", None) is None for f in frames):
             raise UpdateFailed(
                 "All radar tile fetches failed - no frames have data"

--- a/custom_components/rain_incoming/diagnostics.py
+++ b/custom_components/rain_incoming/diagnostics.py
@@ -36,7 +36,7 @@ async def async_get_config_entry_diagnostics(
             "last_update_success_time": str(coordinator.last_update_success_time) if coordinator.last_update_success_time else None,
             "latest_frame_path": coordinator.latest_frame_path,
             "last_rain_nearby_time": str(coordinator.last_rain_nearby_time) if coordinator.last_rain_nearby_time else None,
-            "consecutive_failures": coordinator._consecutive_failures,
+            "consecutive_failures": coordinator.consecutive_failures,
             "update_interval_seconds": coordinator.update_interval.total_seconds() if coordinator.update_interval else None,
         },
         "detection": detection,

--- a/custom_components/rain_incoming/radar/detector.py
+++ b/custom_components/rain_incoming/radar/detector.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from enum import Enum
 
@@ -56,12 +56,8 @@ class DetectionResult:
     confidence: Confidence
     frame_count: int
     max_approaching_intensity: float = 0.0
-    tracked_cells: list[TrackedCell] = None  # type: ignore[assignment]
+    tracked_cells: list[TrackedCell] = field(default_factory=list)
     last_labeled: np.ndarray | None = None  # labeled array of last frame's cells
-
-    def __post_init__(self) -> None:
-        if self.tracked_cells is None:
-            self.tracked_cells = []
 
 
 def _location_to_pixel(

--- a/custom_components/rain_incoming/radar/motion.py
+++ b/custom_components/rain_incoming/radar/motion.py
@@ -85,7 +85,7 @@ def is_directionally_coherent(
         return False
 
     # Reject all-zero velocities - stationary echoes have no meaningful direction
-    non_zero = [(vy, vx) for vy, vx in velocities if vy != 0.0 or vx != 0.0]
+    non_zero = [(vy, vx) for vy, vx in velocities if abs(vy) > 1e-9 or abs(vx) > 1e-9]
     if not non_zero:
         return False
 


### PR DESCRIPTION
**Closes #94, #106, #109, #110**

## Changes
- **#94**: `vy != 0.0` -> `abs(vy) > 1e-9` in motion.py (defensive float comparison)
- **#106**: Move inline `import numpy/math/os` to module level in coordinator.py
- **#109**: Expose `consecutive_failures` as property on coordinator, use in diagnostics instead of private attr
- **#110**: Replace `tracked_cells: list = None  # type: ignore` + `__post_init__` with `field(default_factory=list)`

## Approach
Pure refactoring - no behavior changes, no test changes. All 437 tests pass unchanged.