### PR TITLE
Batch cleanups: shared device_info, User-Agent headers, concurrent coverage probes

### DIFF
--- a/custom_components/rain_incoming/binary_sensor.py
+++ b/custom_components/rain_incoming/binary_sensor.py
@@ -7,7 +7,8 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_LOCATION_NAME, DOMAIN
+from .const import DOMAIN
+from .entity_helpers import device_info_from_entry
 from .coordinator import RainDetectorCoordinator
 from .radar.detector import Confidence
 
@@ -35,14 +36,7 @@ class RainIncomingBinarySensor(CoordinatorEntity[RainDetectorCoordinator], Binar
 
     @property
     def device_info(self) -> DeviceInfo:
-        location_name = self._entry.data.get(CONF_LOCATION_NAME) or ""
-        device_name = "Rain Incoming"
-        if location_name:
-            device_name = f"Rain Incoming - {location_name}"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._entry.entry_id)},
-            name=device_name,
-        )
+        return device_info_from_entry(self._entry)
 
     @property
     def icon(self) -> str:

--- a/custom_components/rain_incoming/entity_helpers.py
+++ b/custom_components/rain_incoming/entity_helpers.py
@@ -1,0 +1,19 @@
+"""Shared entity helpers used across binary_sensor, sensor, and image entities."""
+from __future__ import annotations
+
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.entity import DeviceInfo
+
+from .const import CONF_LOCATION_NAME, DOMAIN
+
+
+def device_info_from_entry(entry: ConfigEntry) -> DeviceInfo:
+    """Build a DeviceInfo grouping all entities under a single Rain Incoming device."""
+    location_name = entry.data.get(CONF_LOCATION_NAME) or ""
+    device_name = "Rain Incoming"
+    if location_name:
+        device_name = f"Rain Incoming - {location_name}"
+    return DeviceInfo(
+        identifiers={(DOMAIN, entry.entry_id)},
+        name=device_name,
+    )

--- a/custom_components/rain_incoming/http_retry.py
+++ b/custom_components/rain_incoming/http_retry.py
@@ -116,6 +116,7 @@ async def fetch_with_retry(
     base_delay: float = 1.0,
     budget: RateLimitBudget | None = None,
     timeout_total: float = 30.0,
+    headers: dict[str, str] | None = None,
 ) -> aiohttp.ClientResponse:
     """Fetch a URL with retry on 429/5xx, respecting Retry-After headers.
 
@@ -137,7 +138,7 @@ async def fetch_with_retry(
                 await asyncio.sleep(delay)
 
         try:
-            resp = await session.get(url, timeout=request_timeout)
+            resp = await session.get(url, timeout=request_timeout, headers=headers)
         except (asyncio.TimeoutError, aiohttp.ServerTimeoutError):
             if attempt < max_retries:
                 delay = base_delay * (2 ** attempt)

--- a/custom_components/rain_incoming/image.py
+++ b/custom_components/rain_incoming/image.py
@@ -20,6 +20,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_LOCATION_NAME, DOMAIN, RADAR_GIF_FRAME_DURATION_MS, RADAR_RADII_KM
 from .coordinator import RainDetectorCoordinator
+from .entity_helpers import device_info_from_entry
 from .radar.composite import render_animated_composite
 
 # Per-render timeout: set below HA image_proxy's ~60s default so a slow render
@@ -74,14 +75,7 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        location_name = self._entry.data.get(CONF_LOCATION_NAME) or ""
-        device_name = "Rain Incoming"
-        if location_name:
-            device_name = f"Rain Incoming - {location_name}"
-        return DeviceInfo(
-            identifiers={(DOMAIN, self._entry.entry_id)},
-            name=device_name,
-        )
+        return device_info_from_entry(self._entry)
 
     @property
     def image_last_updated(self) -> datetime | None:

--- a/custom_components/rain_incoming/providers/rainviewer.py
+++ b/custom_components/rain_incoming/providers/rainviewer.py
@@ -337,7 +337,8 @@ async def check_coverage(
             return False
 
         indices = {0, len(past) // 2, len(past) - 1}
-        for idx in indices:
+
+        async def _probe(idx: int) -> bool:
             frame = past[idx]
             url = (
                 f"{TILE_BASE_URL}{frame['path']}"
@@ -346,13 +347,12 @@ async def check_coverage(
             )
             tile_resp = await fetch_with_retry(session, url)
             tile_bytes = await tile_resp.read()
-
             img = Image.open(BytesIO(tile_bytes)).convert("RGBA")
             alpha = np.array(img)[:, :, 3]
-            if alpha.max() > 10:
-                return True
+            return bool(alpha.max() > 10)
 
-        return False
+        results = await asyncio.gather(*[_probe(i) for i in indices])
+        return any(results)
     finally:
         if owns_session:
             await session.close()

--- a/custom_components/rain_incoming/radar/map_styles.py
+++ b/custom_components/rain_incoming/radar/map_styles.py
@@ -65,7 +65,9 @@ async def _fetch_png(session: aiohttp.ClientSession, url: str) -> Image.Image | 
     Network/timeout errors are also logged at WARNING and return None.
     """
     try:
-        resp = await fetch_with_retry(session, url)
+        resp = await fetch_with_retry(
+            session, url, headers={"User-Agent": _USER_AGENT},
+        )
         data = await resp.read()
         return Image.open(BytesIO(data)).convert("RGBA")
     except aiohttp.ClientResponseError as exc:

--- a/custom_components/rain_incoming/sensor.py
+++ b/custom_components/rain_incoming/sensor.py
@@ -10,8 +10,9 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_LOCATION_NAME, DOMAIN
+from .const import DOMAIN
 from .coordinator import RainDetectorCoordinator
+from .entity_helpers import device_info_from_entry
 from .radar.detector import Confidence
 
 _LOGGER = logging.getLogger(__name__)
@@ -38,15 +39,6 @@ _INTENSITY_ICONS = {
 }
 
 
-def _device_info(entry: ConfigEntry) -> DeviceInfo:
-    location_name = entry.data.get(CONF_LOCATION_NAME) or ""
-    device_name = "Rain Incoming"
-    if location_name:
-        device_name = f"Rain Incoming - {location_name}"
-    return DeviceInfo(
-        identifiers={(DOMAIN, entry.entry_id)},
-        name=device_name,
-    )
 
 
 async def async_setup_entry(
@@ -76,7 +68,7 @@ class RainArrivalTimeSensor(CoordinatorEntity[RainDetectorCoordinator], SensorEn
 
     @property
     def device_info(self) -> DeviceInfo:
-        return _device_info(self._entry)
+        return device_info_from_entry(self._entry)
 
     @property
     def icon(self) -> str:
@@ -122,7 +114,7 @@ class RainIntensitySensor(CoordinatorEntity[RainDetectorCoordinator], SensorEnti
 
     @property
     def device_info(self) -> DeviceInfo:
-        return _device_info(self._entry)
+        return device_info_from_entry(self._entry)
 
     @property
     def icon(self) -> str:
@@ -171,7 +163,7 @@ class LastRainNearbySensor(
 
     @property
     def device_info(self) -> DeviceInfo:
-        return _device_info(self._entry)
+        return device_info_from_entry(self._entry)
 
     async def async_added_to_hass(self) -> None:
         await super().async_added_to_hass()

--- a/tests/unit/providers/test_rainviewer.py
+++ b/tests/unit/providers/test_rainviewer.py
@@ -298,10 +298,22 @@ class TestCheckCoverage:
         tile_resp = AsyncMock()
         tile_resp.read = AsyncMock(return_value=_make_tile_png(has_precip=True))
 
+        # check_coverage fetches manifest first (sequential), then probes
+        # tiles concurrently. Use a function side_effect that returns the
+        # manifest for the first call and tile responses for the rest.
+        call_count = 0
+
+        async def _fake_fetch(session, url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return manifest_resp
+            return tile_resp
+
         mock_session = MagicMock()
         with patch(
             "custom_components.rain_incoming.providers.rainviewer.fetch_with_retry",
-            side_effect=[manifest_resp, tile_resp],
+            side_effect=_fake_fetch,
         ):
             result = await check_coverage(-33.701, 151.209, session=mock_session)
         assert result is True
@@ -314,10 +326,19 @@ class TestCheckCoverage:
         tile_resp = AsyncMock()
         tile_resp.read = AsyncMock(return_value=_make_tile_png(has_precip=False))
 
+        call_count = 0
+
+        async def _fake_fetch(session, url, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return manifest_resp
+            return tile_resp
+
         mock_session = MagicMock()
         with patch(
             "custom_components.rain_incoming.providers.rainviewer.fetch_with_retry",
-            side_effect=[manifest_resp, tile_resp, tile_resp, tile_resp],
+            side_effect=_fake_fetch,
         ):
             result = await check_coverage(0.0, 0.0, session=mock_session)
         assert result is False


### PR DESCRIPTION
**Closes #104, #105, #107**

## Changes
- **#105 M1**: Extract `device_info_from_entry()` to `entity_helpers.py`, replace 3 duplicated blocks in binary_sensor/image/sensor
- **#104 I8**: Pass `_USER_AGENT` header to map tile requests (OSM tile usage policy). Added `headers` param to `fetch_with_retry`.
- **#107 M3**: `check_coverage` now probes 3 tiles concurrently via `asyncio.gather` (faster config flow setup). Test mocks updated for concurrent ordering.

## Test plan
- [x] All 437 tests pass
- [x] check_coverage tests adapted for concurrent probe ordering