### PR TITLE
I7: Options flow single storage + I6 backoff test coverage

### DIFF
--- a/custom_components/rain_incoming/config_flow.py
+++ b/custom_components/rain_incoming/config_flow.py
@@ -262,6 +262,8 @@ class RainIncomingOptionsFlow(OptionsFlow):
                     merged_data[CONF_LOCATION_NAME] = user_input[CONF_LOCATION_NAME]
                 if CONF_LOOKAHEAD_MINUTES in user_input:
                     merged_data[CONF_LOOKAHEAD_MINUTES] = user_input[CONF_LOOKAHEAD_MINUTES]
+                if CONF_MAP_STYLE in user_input:
+                    merged_data[CONF_MAP_STYLE] = user_input[CONF_MAP_STYLE]
 
                 self.hass.config_entries.async_update_entry(
                     self._config_entry,
@@ -270,12 +272,14 @@ class RainIncomingOptionsFlow(OptionsFlow):
                 )
                 # Trigger reload so the coordinator picks up the new style immediately.
                 self.hass.config_entries.async_schedule_reload(self._config_entry.entry_id)
-                return self.async_create_entry(data=user_input)
+                # Return empty options - all values are stored in entry.data.
+                # Avoids dual storage where the same values live in both
+                # data and options, creating a divergence risk.
+                return self.async_create_entry(data={})
 
-        # Pre-populate from current options (preferred) then data (fallback).
+        # Pre-populate from entry.data (canonical source of truth).
         # When re-rendering after a validation error, use what the user typed so
         # they don't have to retype values they already entered correctly.
-        current_options = self._config_entry.options
         current_data = self._config_entry.data
         if user_input is not None:
             # Re-render after validation failure: restore what the user typed.
@@ -285,20 +289,12 @@ class RainIncomingOptionsFlow(OptionsFlow):
             default_location_name = user_input.get(CONF_LOCATION_NAME, "")
             default_map_style = user_input.get(CONF_MAP_STYLE, _DEFAULT_MAP_STYLE)
         else:
-            # First render: use persisted values.
+            # First render: use persisted values from entry.data.
             default_lat = current_data.get(CONF_LATITUDE, 0.0)
             default_lon = current_data.get(CONF_LONGITUDE, 0.0)
-            default_lookahead = current_options.get(
-                CONF_LOOKAHEAD_MINUTES,
-                current_data.get(CONF_LOOKAHEAD_MINUTES, DEFAULT_LOOKAHEAD_MINUTES),
-            )
-            default_location_name = current_options.get(
-                CONF_LOCATION_NAME,
-                current_data.get(CONF_LOCATION_NAME, ""),
-            )
-            default_map_style = current_options.get(
-                CONF_MAP_STYLE,
-                current_data.get(CONF_MAP_STYLE, _DEFAULT_MAP_STYLE),
+            default_lookahead = current_data.get(CONF_LOOKAHEAD_MINUTES, DEFAULT_LOOKAHEAD_MINUTES)
+            default_location_name = current_data.get(CONF_LOCATION_NAME, "")
+            default_map_style = current_data.get(CONF_MAP_STYLE, _DEFAULT_MAP_STYLE,
             )
         schema = _build_options_schema(
             default_lat=default_lat,

--- a/custom_components/rain_incoming/coordinator.py
+++ b/custom_components/rain_incoming/coordinator.py
@@ -158,11 +158,8 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
 
     @property
     def map_style(self) -> str:
-        """Return the active map style, reading options first then data then default."""
-        return self._entry.options.get(
-            CONF_MAP_STYLE,
-            self._entry.data.get(CONF_MAP_STYLE, "voyager"),
-        )
+        """Return the active map style from entry.data."""
+        return self._entry.data.get(CONF_MAP_STYLE, "voyager")
 
     @property
     def consecutive_failures(self) -> int:

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -252,7 +252,9 @@ async def test_options_flow_changes_map_style(hass: HomeAssistant):
         },
     )
     assert result["type"] == FlowResultType.CREATE_ENTRY
-    assert entry.options[CONF_MAP_STYLE] == "esri_imagery"
+    # Options flow stores all values in entry.data (not entry.options) to
+    # avoid dual storage. The coordinator reads from data only.
+    assert entry.data[CONF_MAP_STYLE] == "esri_imagery"
 
 
 @pytest.mark.asyncio
@@ -357,7 +359,8 @@ async def test_migration_does_not_re_migrate_v2_entry(hass: HomeAssistant):
 
 
 @pytest.mark.asyncio
-async def test_coordinator_uses_options_map_style_over_data(hass: HomeAssistant):
+async def test_coordinator_reads_map_style_from_data(hass: HomeAssistant):
+    """map_style reads from entry.data (canonical source). Options are ignored."""
     from custom_components.rain_incoming.coordinator import RainDetectorCoordinator
 
     entry = MockConfigEntry(
@@ -366,9 +369,9 @@ async def test_coordinator_uses_options_map_style_over_data(hass: HomeAssistant)
             "latitude": -33.701,
             "longitude": 151.209,
             "lookahead_minutes": 60,
-            CONF_MAP_STYLE: "voyager",
+            CONF_MAP_STYLE: "esri_imagery",
         },
-        options={CONF_MAP_STYLE: "esri_imagery"},
+        options={},
         version=2,
     )
     entry.add_to_hass(hass)

--- a/tests/unit/test_fetch_with_backoff.py
+++ b/tests/unit/test_fetch_with_backoff.py
@@ -1,0 +1,77 @@
+"""Tests for coordinator._fetch_with_backoff retry limits.
+
+I6: _fetch_with_backoff must cap the number of retry attempts to avoid
+blocking _async_update_data for 255+ seconds.
+"""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from custom_components.rain_incoming.coordinator import RainDetectorCoordinator
+from custom_components.rain_incoming.const import BACKOFF_MAX_SECONDS
+
+
+def _make_coordinator():
+    hass = MagicMock()
+    hass.config.latitude = -33.7
+    hass.config.longitude = 151.2
+    hass.config.path.return_value = "/fake/.storage"
+    entry = MagicMock()
+    entry.entry_id = "test"
+    entry.data = {"latitude": -33.7, "longitude": 151.2, "lookahead_minutes": 60}
+    return RainDetectorCoordinator(hass, entry)
+
+
+class TestFetchWithBackoff:
+    @pytest.mark.asyncio
+    async def test_raises_after_max_retries_not_indefinitely(self):
+        """_fetch_with_backoff must raise after a bounded number of attempts,
+        not loop until backoff >= BACKOFF_MAX_SECONDS."""
+        coordinator = _make_coordinator()
+        call_count = 0
+
+        async def _failing_get_frames(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            raise ConnectionError("network down")
+
+        with patch.object(
+            coordinator._provider, "get_frames", side_effect=_failing_get_frames,
+        ):
+            with patch("custom_components.rain_incoming.coordinator.asyncio.sleep", new=AsyncMock()):
+                with pytest.raises(ConnectionError):
+                    await coordinator._fetch_with_backoff(-33.7, 151.2)
+
+        # Must not attempt more than 5 times (base=5, *2, *2, *2 = 40, *2 = 80 > 60 -> raise)
+        # The exact count depends on the backoff progression but must be bounded.
+        assert call_count <= 5, (
+            f"_fetch_with_backoff made {call_count} attempts - must be bounded to "
+            f"avoid blocking _async_update_data for hundreds of seconds"
+        )
+
+    @pytest.mark.asyncio
+    async def test_succeeds_on_retry(self):
+        """_fetch_with_backoff must return frames when a retry succeeds."""
+        coordinator = _make_coordinator()
+        mock_frames = [MagicMock(), MagicMock()]
+
+        call_count = 0
+
+        async def _flaky_get_frames(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count < 3:
+                raise ConnectionError("transient")
+            return mock_frames
+
+        with patch.object(
+            coordinator._provider, "get_frames", side_effect=_flaky_get_frames,
+        ):
+            with patch("custom_components.rain_incoming.coordinator.asyncio.sleep", new=AsyncMock()):
+                result = await coordinator._fetch_with_backoff(-33.7, 151.2)
+
+        assert result == mock_frames
+        assert call_count == 3
+        assert coordinator.consecutive_failures == 0


### PR DESCRIPTION
**Closes #103**

## I7: Options flow dual storage fix
Options flow was storing values in both `entry.data` AND `entry.options`. Now:
- All values stored in `entry.data` only (canonical source)
- Options flow returns `async_create_entry(data={})`
- Coordinator reads `map_style` from `data` only (no options fallback)
- Added `CONF_MAP_STYLE` to the data merge (was previously only saved via options)

## I6: Backoff test coverage
Added unit tests confirming `_fetch_with_backoff` is already bounded (4 retries, 75s sleep). #95 closed separately.

## Test changes
- `test_options_flow_changes_map_style`: asserts on `entry.data` not `entry.options`
- `test_coordinator_reads_map_style_from_data`: replaces old options-over-data test
- 2 new backoff tests

## Test plan
- [x] All 439 tests pass