### PR TITLE
Reset asyncio primitives on last entry unload (#122)

### DIFF
--- a/custom_components/rain_incoming/__init__.py
+++ b/custom_components/rain_incoming/__init__.py
@@ -91,8 +91,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     if unload_ok := await hass.config_entries.async_unload_platforms(entry, PLATFORMS):
         hass.data[DOMAIN].pop(entry.entry_id)
-        # Clear tile caches when the last entry is unloaded to free memory
+        # Reset module-level state when the last entry is unloaded
         if not hass.data[DOMAIN]:
             from .radar.composite import clear_tile_caches
+            from .image import reset_render_lock
             clear_tile_caches()
+            reset_render_lock()
     return unload_ok

--- a/custom_components/rain_incoming/image.py
+++ b/custom_components/rain_incoming/image.py
@@ -43,6 +43,12 @@ def _get_render_lock() -> asyncio.Lock:
     return _render_lock
 
 
+def reset_render_lock() -> None:
+    """Reset the render lock. Called when the last config entry is unloaded."""
+    global _render_lock
+    _render_lock = None
+
+
 async def async_setup_entry(
     hass: HomeAssistant,
     entry: ConfigEntry,

--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -51,9 +51,11 @@ _RADAR_CACHE_MAX = 500
 
 
 def clear_tile_caches() -> None:
-    """Clear both tile caches. Called when the last config entry is unloaded."""
+    """Clear tile caches and reset the semaphore. Called when the last entry is unloaded."""
+    global _tile_semaphore
     _map_tile_cache.clear()
     _radar_tile_cache.clear()
+    _tile_semaphore = None
 
 # Semaphore to limit concurrent tile fetches (shared across map + radar)
 _tile_semaphore: asyncio.Semaphore | None = None

--- a/tests/unit/radar/test_cache_cleanup.py
+++ b/tests/unit/radar/test_cache_cleanup.py
@@ -11,6 +11,7 @@ from PIL import Image
 from custom_components.rain_incoming.radar.composite import (
     _map_tile_cache,
     _radar_tile_cache,
+    _tile_semaphore,
     _MAP_CACHE_MAX,
     clear_tile_caches,
 )
@@ -96,3 +97,35 @@ class TestUnloadClearsCaches:
 
         assert len(_map_tile_cache) == 0, "Map cache must be cleared after last entry unload"
         assert len(_radar_tile_cache) == 0, "Radar cache must be cleared after last entry unload"
+
+
+class TestAsyncPrimitivesResetOnClear:
+    """clear_tile_caches must reset the tile semaphore and render lock
+    so they're recreated fresh after integration reload (#122)."""
+
+    def test_tile_semaphore_reset_on_clear(self):
+        import custom_components.rain_incoming.radar.composite as comp
+
+        # Force creation
+        comp._get_tile_semaphore()
+        assert comp._tile_semaphore is not None
+
+        clear_tile_caches()
+
+        assert comp._tile_semaphore is None, (
+            "Tile semaphore must be reset to None after clear_tile_caches"
+        )
+
+    def test_render_lock_reset_on_clear(self):
+        import custom_components.rain_incoming.image as img_mod
+
+        # Force creation
+        img_mod._get_render_lock()
+        assert img_mod._render_lock is not None
+
+        from custom_components.rain_incoming.image import reset_render_lock
+        reset_render_lock()
+
+        assert img_mod._render_lock is None, (
+            "Render lock must be reset to None after reset_render_lock"
+        )


### PR DESCRIPTION
**Closes #122**

## Problem
The render lock and tile semaphore are module-level globals that persist across integration reload. A cancelled render task during unload could leave the lock acquired, blocking all future renders.

## Fix
- `clear_tile_caches()` now also resets `_tile_semaphore = None`
- New `reset_render_lock()` in image.py resets `_render_lock = None`
- Both called from `async_unload_entry` when the last entry is removed

## TDD
- `test_tile_semaphore_reset_on_clear` - RED then GREEN
- `test_render_lock_reset_on_clear` - RED then GREEN

## Test plan
- [x] 7 cache cleanup tests pass
- [x] Full suite passes (443 tests)