### PR TITLE
Add Raining binary sensor for overhead rain (Wet/Dry)

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ automation:
 | Entity | Type | Description |
 |---|---|---|
 | `binary_sensor.rain_incoming_imminent` | Binary | `on` when rain is approaching or overhead, `off` when clear |
-| `binary_sensor.rain_incoming_raining` | Binary (moisture) | `Wet` when rain is at the location (overhead), `Dry` otherwise |
+| `binary_sensor.rain_incoming_raining_now` | Binary (moisture) | `Wet` when rain is at the location (overhead), `Dry` otherwise |
 | `sensor.rain_incoming_arrival_time` | Timestamp | Predicted arrival time, `unknown` when no rain incoming |
 | `sensor.rain_incoming_intensity` | Sensor | Precipitation intensity: `none` / `light` / `moderate` / `heavy` / `extreme` |
 | `sensor.rain_incoming_last_rain` | Timestamp | Last time rain was detected nearby |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ automation:
   - alias: "Close pergola cover - rain incoming"
     trigger:
       - platform: state
-        entity_id: binary_sensor.rain_incoming_status
+        entity_id: binary_sensor.rain_incoming_imminent
         to: "on"
     action:
       - service: cover.close_cover
@@ -132,7 +132,7 @@ automation:
   - alias: "Return lawnmower - rain close and heavy enough"
     trigger:
       - platform: state
-        entity_id: binary_sensor.rain_incoming_status
+        entity_id: binary_sensor.rain_incoming_imminent
         to: "on"
     condition:
       - condition: template
@@ -157,7 +157,7 @@ automation:
   - alias: "Washing alert - rain incoming"
     trigger:
       - platform: state
-        entity_id: binary_sensor.rain_incoming_status
+        entity_id: binary_sensor.rain_incoming_imminent
         to: "on"
     condition:
       - condition: time
@@ -183,7 +183,7 @@ automation:
   - alias: "Cancel irrigation - already raining"
     trigger:
       - platform: state
-        entity_id: binary_sensor.rain_incoming_status
+        entity_id: binary_sensor.rain_incoming_imminent
         to: "on"
     condition:
       - condition: template
@@ -202,7 +202,7 @@ automation:
 
 | Entity | Type | Description |
 |---|---|---|
-| `binary_sensor.rain_incoming_status` | Binary | `on` when rain is approaching or overhead, `off` when clear |
+| `binary_sensor.rain_incoming_imminent` | Binary | `on` when rain is approaching or overhead, `off` when clear |
 | `binary_sensor.rain_incoming_raining` | Binary (moisture) | `Wet` when rain is at the location (overhead), `Dry` otherwise |
 | `sensor.rain_incoming_arrival_time` | Timestamp | Predicted arrival time, `unknown` when no rain incoming |
 | `sensor.rain_incoming_intensity` | Sensor | Precipitation intensity: `none` / `light` / `moderate` / `heavy` / `extreme` |

--- a/README.md
+++ b/README.md
@@ -202,7 +202,8 @@ automation:
 
 | Entity | Type | Description |
 |---|---|---|
-| `binary_sensor.rain_incoming_status` | Binary (moisture) | `on`/Wet when rain is approaching or overhead, `off`/Dry when clear |
+| `binary_sensor.rain_incoming_status` | Binary | `on` when rain is approaching or overhead, `off` when clear |
+| `binary_sensor.rain_incoming_raining` | Binary (moisture) | `Wet` when rain is at the location (overhead), `Dry` otherwise |
 | `sensor.rain_incoming_arrival_time` | Timestamp | Predicted arrival time, `unknown` when no rain incoming |
 | `sensor.rain_incoming_intensity` | Sensor | Precipitation intensity: `none` / `light` / `moderate` / `heavy` / `extreme` |
 | `sensor.rain_incoming_last_rain` | Timestamp | Last time rain was detected nearby |

--- a/custom_components/rain_incoming/binary_sensor.py
+++ b/custom_components/rain_incoming/binary_sensor.py
@@ -19,15 +19,21 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     coordinator: RainDetectorCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([RainIncomingBinarySensor(coordinator, entry)])
+    async_add_entities([
+        RainIncomingBinarySensor(coordinator, entry),
+        RainingBinarySensor(coordinator, entry),
+    ])
 
 
 class RainIncomingBinarySensor(CoordinatorEntity[RainDetectorCoordinator], BinarySensorEntity):
-    """Binary sensor that is on when rain is detected approaching or at the location."""
+    """Binary sensor that is on when rain is detected approaching or at the location.
+
+    Shows On/Off (no device class) since rain may be 45 minutes away, not
+    currently raining. See RainingBinarySensor for overhead rain (Wet/Dry).
+    """
 
     _attr_has_entity_name = True
     _attr_name = "Status"
-    _attr_device_class = BinarySensorDeviceClass.MOISTURE
 
     def __init__(self, coordinator: RainDetectorCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator)
@@ -69,3 +75,46 @@ class RainIncomingBinarySensor(CoordinatorEntity[RainDetectorCoordinator], Binar
         if self.coordinator.last_update_success_time is not None:
             attrs["last_update_success"] = self.coordinator.last_update_success_time.isoformat()
         return attrs
+
+
+class RainingBinarySensor(CoordinatorEntity[RainDetectorCoordinator], BinarySensorEntity):
+    """Binary sensor that is on only when rain is detected at the location (overhead).
+
+    Uses MOISTURE device class so HA displays Wet/Dry. Only triggers when
+    rain is actually at the monitored location, not when it's approaching.
+    """
+
+    _attr_has_entity_name = True
+    _attr_name = "Raining"
+    _attr_device_class = BinarySensorDeviceClass.MOISTURE
+
+    def __init__(self, coordinator: RainDetectorCoordinator, entry: ConfigEntry) -> None:
+        super().__init__(coordinator)
+        self._entry = entry
+        self._attr_unique_id = f"{entry.entry_id}_raining"
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        return device_info_from_entry(self._entry)
+
+    @property
+    def icon(self) -> str:
+        if self.is_on:
+            return "mdi:weather-pouring"
+        return "mdi:weather-sunny"
+
+    @property
+    def is_on(self) -> bool | None:
+        if self.coordinator.data is None:
+            return None
+        if self.coordinator.data.confidence == Confidence.UNAVAILABLE:
+            return None
+        return self.coordinator.data.rain_at_location
+
+    @property
+    def available(self) -> bool:
+        return (
+            self.coordinator.last_update_success
+            and self.coordinator.data is not None
+            and self.coordinator.data.confidence != Confidence.UNAVAILABLE
+        )

--- a/custom_components/rain_incoming/binary_sensor.py
+++ b/custom_components/rain_incoming/binary_sensor.py
@@ -85,13 +85,13 @@ class RainingBinarySensor(CoordinatorEntity[RainDetectorCoordinator], BinarySens
     """
 
     _attr_has_entity_name = True
-    _attr_name = "Raining"
+    _attr_name = "Raining Now"
     _attr_device_class = BinarySensorDeviceClass.MOISTURE
 
     def __init__(self, coordinator: RainDetectorCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator)
         self._entry = entry
-        self._attr_unique_id = f"{entry.entry_id}_raining"
+        self._attr_unique_id = f"{entry.entry_id}_raining_now"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/rain_incoming/binary_sensor.py
+++ b/custom_components/rain_incoming/binary_sensor.py
@@ -33,12 +33,12 @@ class RainIncomingBinarySensor(CoordinatorEntity[RainDetectorCoordinator], Binar
     """
 
     _attr_has_entity_name = True
-    _attr_name = "Status"
+    _attr_name = "Imminent"
 
     def __init__(self, coordinator: RainDetectorCoordinator, entry: ConfigEntry) -> None:
         super().__init__(coordinator)
         self._entry = entry
-        self._attr_unique_id = f"{entry.entry_id}_rain_incoming"
+        self._attr_unique_id = f"{entry.entry_id}_rain_imminent"
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/rain_incoming/radar/detector.py
+++ b/custom_components/rain_incoming/radar/detector.py
@@ -56,6 +56,7 @@ class DetectionResult:
     confidence: Confidence
     frame_count: int
     max_approaching_intensity: float = 0.0
+    rain_at_location: bool = False
     tracked_cells: list[TrackedCell] = field(default_factory=list)
     last_labeled: np.ndarray | None = None  # labeled array of last frame's cells
 
@@ -540,6 +541,7 @@ def detect(
                 confidence=confidence,
                 frame_count=frame_count,
                 max_approaching_intensity=rain_intensity,
+                rain_at_location=True,
                 tracked_cells=[],
                 last_labeled=per_frame_labeled[-1] if per_frame_labeled else None,
             )
@@ -613,6 +615,7 @@ def detect(
         confidence=confidence,
         frame_count=frame_count,
         max_approaching_intensity=max_intensity if rain_incoming else 0.0,
+        rain_at_location=rain_at_location is not None,
         tracked_cells=tracked_cells,
         last_labeled=last_labeled,
     )

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -383,7 +383,7 @@ def ha_client(ha_container) -> HAClient:
     client = HAClient(token)
     try:
         client.poll_entity_state(
-            "binary_sensor.rain_incoming_status",
+            "binary_sensor.rain_incoming_imminent",
             timeout=30,
             condition=lambda s: s.get("state") not in (None, "unavailable"),
         )
@@ -437,7 +437,7 @@ def configure_location(ha_client):
                 entry_ids.append(entry_id)
         # Poll until the binary sensor for this location is ready
         sensor_slug = name.lower().replace(" ", "_")
-        sensor_id = f"binary_sensor.rain_incoming_{sensor_slug}_status"
+        sensor_id = f"binary_sensor.rain_incoming_{sensor_slug}_imminent"
         try:
             ha_client.poll_entity_state(
                 sensor_id,

--- a/tests/e2e/test_golden_v2_e2e.py
+++ b/tests/e2e/test_golden_v2_e2e.py
@@ -40,7 +40,7 @@ class TestCanberraGoldenV2:
         ha_client.set_mock_scenario("golden_v2:Canberra:5-10")
         configure_location(CANBERRA_LAT, CANBERRA_LON, "Canberra_v2")
 
-        sensor_id = "binary_sensor.rain_incoming_canberra_v2_status"
+        sensor_id = "binary_sensor.rain_incoming_canberra_v2_imminent"
         state = ha_client.wait_for_coordinator_cycle(sensor_id, timeout=60)
 
         # Save rain image for inspection
@@ -57,7 +57,7 @@ class TestCanberraGoldenV2:
     def test_rain_visible_in_image(self, ha_client):
         """The radar image must show visible rain - not just sensor on."""
         image_id = "image.rain_incoming_canberra_v2_radar_128km"
-        sensor_id = "binary_sensor.rain_incoming_canberra_v2_status"
+        sensor_id = "binary_sensor.rain_incoming_canberra_v2_imminent"
 
         # Ensure we have fresh rain data rendered - poll until sensor is in expected state
         ha_client.update_entity(sensor_id)
@@ -112,7 +112,7 @@ class TestCanberraGoldenV2:
     def test_no_rain_when_classified_none(self, ha_client):
         """Frames 0-2 are all 'none'. With only none frames, sensor should be off."""
         ha_client.set_mock_scenario("golden_v2:Canberra:0-2")
-        sensor_id = "binary_sensor.rain_incoming_canberra_v2_status"
+        sensor_id = "binary_sensor.rain_incoming_canberra_v2_imminent"
         ha_client.update_entity(sensor_id)
         state = ha_client.poll_entity_state(
             sensor_id, timeout=30,
@@ -136,7 +136,7 @@ class TestCanberraGoldenV2:
         the entity unavailable.
         """
         ha_client.set_mock_scenario("golden_v2:Canberra:0-2")
-        sensor_id = "binary_sensor.rain_incoming_canberra_v2_status"
+        sensor_id = "binary_sensor.rain_incoming_canberra_v2_imminent"
         ha_client.update_entity(sensor_id)
         state = ha_client.poll_entity_state(
             sensor_id, timeout=30,
@@ -157,9 +157,9 @@ class TestCanberraGoldenV2:
         can incidentally match precipitation colour thresholds.
         """
         ha_client.set_mock_scenario("golden_v2:Canberra:0-2")
-        ha_client.update_entity("binary_sensor.rain_incoming_canberra_v2_status")
+        ha_client.update_entity("binary_sensor.rain_incoming_canberra_v2_imminent")
         ha_client.poll_entity_state(
-            "binary_sensor.rain_incoming_canberra_v2_status", timeout=30,
+            "binary_sensor.rain_incoming_canberra_v2_imminent", timeout=30,
             condition=lambda s: s.get("state") == "off",
         )
 
@@ -184,9 +184,9 @@ class TestCanberraGoldenV2:
         test is meaningless - it would pass even when the pipeline is broken.
         """
         ha_client.set_mock_scenario("golden_v2:Canberra:5-10")
-        ha_client.update_entity("binary_sensor.rain_incoming_canberra_v2_status")
+        ha_client.update_entity("binary_sensor.rain_incoming_canberra_v2_imminent")
         state = ha_client.poll_entity_state(
-            "binary_sensor.rain_incoming_canberra_v2_status", timeout=30,
+            "binary_sensor.rain_incoming_canberra_v2_imminent", timeout=30,
             condition=lambda s: s.get("state") == "on",
         )
         assert state["state"] != "off", (
@@ -210,7 +210,7 @@ class TestDarwinGoldenV2:
         ha_client.set_mock_scenario("golden_v2:Darwin:5-12")
         configure_location(DARWIN_LAT, DARWIN_LON, "Darwin_v2")
 
-        sensor_id = "binary_sensor.rain_incoming_darwin_v2_status"
+        sensor_id = "binary_sensor.rain_incoming_darwin_v2_imminent"
         state = ha_client.wait_for_coordinator_cycle(sensor_id, timeout=60)
 
         image_id = "image.rain_incoming_darwin_v2_radar_128km"
@@ -231,7 +231,7 @@ class TestDarwinGoldenV2:
         for precipitation-coloured pixels in the rendered image.
         """
         image_id = "image.rain_incoming_darwin_v2_radar_128km"
-        sensor_id = "binary_sensor.rain_incoming_darwin_v2_status"
+        sensor_id = "binary_sensor.rain_incoming_darwin_v2_imminent"
 
         # Ensure we have fresh rain data rendered - poll until sensor is in expected state
         ha_client.update_entity(sensor_id)
@@ -268,7 +268,7 @@ class TestMelbourneGoldenV2:
         ha_client.set_mock_scenario("golden_v2:Melbourne:1-12")
         configure_location(MELBOURNE_LAT, MELBOURNE_LON, "Melbourne_v2")
 
-        sensor_id = "binary_sensor.rain_incoming_melbourne_v2_status"
+        sensor_id = "binary_sensor.rain_incoming_melbourne_v2_imminent"
         # Wait for a complete coordinator cycle with the dry scenario.
         # configure_location's internal poll accepts any non-unavailable state,
         # which may capture a transient "on" from the coordinator's initial
@@ -293,7 +293,7 @@ class TestMelbourneGoldenV2:
         classify this as dry overall.
         """
         ha_client.set_mock_scenario("golden_v2:Melbourne:0-12")
-        sensor_id = "binary_sensor.rain_incoming_melbourne_v2_status"
+        sensor_id = "binary_sensor.rain_incoming_melbourne_v2_imminent"
         ha_client.update_entity(sensor_id)
         state = ha_client.poll_entity_state(
             sensor_id, timeout=30,

--- a/tests/e2e/test_sensors_e2e.py
+++ b/tests/e2e/test_sensors_e2e.py
@@ -19,7 +19,7 @@ import time
 from tests.e2e.image_helpers import images_differ_significantly
 
 
-BINARY_SENSOR = "binary_sensor.rain_incoming_status"
+BINARY_SENSOR = "binary_sensor.rain_incoming_imminent"
 ARRIVAL_SENSOR = "sensor.rain_incoming_arrival_time"
 INTENSITY_SENSOR = "sensor.rain_incoming_intensity"
 IMAGE_128 = "image.rain_incoming_radar_128km"

--- a/tests/integration/test_sensors.py
+++ b/tests/integration/test_sensors.py
@@ -185,7 +185,7 @@ async def test_binary_sensor_status_has_no_device_class(hass: HomeAssistant, moc
 async def test_raining_sensor_exists(hass: HomeAssistant, mock_entry):
     """A separate Raining binary sensor must exist."""
     await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
-    state = hass.states.get("binary_sensor.rain_incoming_raining")
+    state = hass.states.get("binary_sensor.rain_incoming_raining_now")
     assert state is not None
 
 
@@ -193,7 +193,7 @@ async def test_raining_sensor_exists(hass: HomeAssistant, mock_entry):
 async def test_raining_sensor_device_class_is_moisture(hass: HomeAssistant, mock_entry):
     """Raining sensor shows Wet/Dry - uses moisture device class."""
     await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
-    state = hass.states.get("binary_sensor.rain_incoming_raining")
+    state = hass.states.get("binary_sensor.rain_incoming_raining_now")
     assert state is not None
     assert state.attributes.get("device_class") == BinarySensorDeviceClass.MOISTURE
 
@@ -202,7 +202,7 @@ async def test_raining_sensor_device_class_is_moisture(hass: HomeAssistant, mock
 async def test_raining_sensor_off_when_no_rain(hass: HomeAssistant, mock_entry):
     """Raining sensor must be off when there's no rain."""
     await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
-    state = hass.states.get("binary_sensor.rain_incoming_raining")
+    state = hass.states.get("binary_sensor.rain_incoming_raining_now")
     assert state is not None
     assert state.state == "off"
 

--- a/tests/integration/test_sensors.py
+++ b/tests/integration/test_sensors.py
@@ -173,11 +173,38 @@ def test_translations_en_json_matches_strings_json():
 
 
 @pytest.mark.asyncio
-async def test_binary_sensor_device_class_is_moisture(hass: HomeAssistant, mock_entry):
+async def test_binary_sensor_status_has_no_device_class(hass: HomeAssistant, mock_entry):
+    """Status sensor shows On/Off (not Wet/Dry) - no device class."""
     await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
     state = hass.states.get("binary_sensor.rain_incoming_status")
     assert state is not None
+    assert state.attributes.get("device_class") is None
+
+
+@pytest.mark.asyncio
+async def test_raining_sensor_exists(hass: HomeAssistant, mock_entry):
+    """A separate Raining binary sensor must exist."""
+    await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
+    state = hass.states.get("binary_sensor.rain_incoming_raining")
+    assert state is not None
+
+
+@pytest.mark.asyncio
+async def test_raining_sensor_device_class_is_moisture(hass: HomeAssistant, mock_entry):
+    """Raining sensor shows Wet/Dry - uses moisture device class."""
+    await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
+    state = hass.states.get("binary_sensor.rain_incoming_raining")
+    assert state is not None
     assert state.attributes.get("device_class") == BinarySensorDeviceClass.MOISTURE
+
+
+@pytest.mark.asyncio
+async def test_raining_sensor_off_when_no_rain(hass: HomeAssistant, mock_entry):
+    """Raining sensor must be off when there's no rain."""
+    await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
+    state = hass.states.get("binary_sensor.rain_incoming_raining")
+    assert state is not None
+    assert state.state == "off"
 
 
 # --- Dynamic icons ---

--- a/tests/integration/test_sensors.py
+++ b/tests/integration/test_sensors.py
@@ -57,7 +57,7 @@ def mock_entry():
 @pytest.mark.asyncio
 async def test_binary_sensor_unavailable_when_no_data(hass: HomeAssistant, mock_entry):
     await setup_integration(hass, mock_entry, MOCK_RESULT_UNAVAILABLE)
-    state = hass.states.get("binary_sensor.rain_incoming_status")
+    state = hass.states.get("binary_sensor.rain_incoming_imminent")
     assert state is not None
     assert state.state == "unavailable"
 
@@ -65,7 +65,7 @@ async def test_binary_sensor_unavailable_when_no_data(hass: HomeAssistant, mock_
 @pytest.mark.asyncio
 async def test_binary_sensor_on_when_rain_coming(hass: HomeAssistant, mock_entry):
     await setup_integration(hass, mock_entry, MOCK_RESULT_RAIN_COMING)
-    state = hass.states.get("binary_sensor.rain_incoming_status")
+    state = hass.states.get("binary_sensor.rain_incoming_imminent")
     assert state is not None
     assert state.state == "on"
     assert state.attributes["confidence"] == "normal"
@@ -74,7 +74,7 @@ async def test_binary_sensor_on_when_rain_coming(hass: HomeAssistant, mock_entry
 @pytest.mark.asyncio
 async def test_binary_sensor_off_when_no_rain(hass: HomeAssistant, mock_entry):
     await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
-    state = hass.states.get("binary_sensor.rain_incoming_status")
+    state = hass.states.get("binary_sensor.rain_incoming_imminent")
     assert state is not None
     assert state.state == "off"
 
@@ -176,7 +176,7 @@ def test_translations_en_json_matches_strings_json():
 async def test_binary_sensor_status_has_no_device_class(hass: HomeAssistant, mock_entry):
     """Status sensor shows On/Off (not Wet/Dry) - no device class."""
     await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
-    state = hass.states.get("binary_sensor.rain_incoming_status")
+    state = hass.states.get("binary_sensor.rain_incoming_imminent")
     assert state is not None
     assert state.attributes.get("device_class") is None
 
@@ -213,14 +213,14 @@ async def test_raining_sensor_off_when_no_rain(hass: HomeAssistant, mock_entry):
 @pytest.mark.asyncio
 async def test_binary_sensor_icon_pouring_when_rain(hass: HomeAssistant, mock_entry):
     await setup_integration(hass, mock_entry, MOCK_RESULT_RAIN_COMING)
-    state = hass.states.get("binary_sensor.rain_incoming_status")
+    state = hass.states.get("binary_sensor.rain_incoming_imminent")
     assert state.attributes["icon"] == "mdi:weather-pouring"
 
 
 @pytest.mark.asyncio
 async def test_binary_sensor_icon_sunny_when_no_rain(hass: HomeAssistant, mock_entry):
     await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
-    state = hass.states.get("binary_sensor.rain_incoming_status")
+    state = hass.states.get("binary_sensor.rain_incoming_imminent")
     assert state.attributes["icon"] == "mdi:weather-sunny"
 
 
@@ -243,7 +243,7 @@ async def test_arrival_sensor_icon_clock_when_no_rain(hass: HomeAssistant, mock_
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize("entity_id", [
-    "binary_sensor.rain_incoming_status",
+    "binary_sensor.rain_incoming_imminent",
     "sensor.rain_incoming_arrival_time",
 ])
 async def test_config_values_not_in_attributes(hass: HomeAssistant, mock_entry, entity_id):
@@ -267,7 +267,7 @@ async def test_binary_sensor_exposes_last_update_success_attribute(hass: HomeAss
     coordinator.async_set_updated_data(MOCK_RESULT_RAIN_COMING)
     await hass.async_block_till_done()
 
-    state = hass.states.get("binary_sensor.rain_incoming_status")
+    state = hass.states.get("binary_sensor.rain_incoming_imminent")
     assert state is not None
     assert "last_update_success" in state.attributes
     value = state.attributes["last_update_success"]
@@ -277,7 +277,7 @@ async def test_binary_sensor_exposes_last_update_success_attribute(hass: HomeAss
 @pytest.mark.asyncio
 async def test_binary_sensor_still_has_dynamic_attributes(hass: HomeAssistant, mock_entry):
     await setup_integration(hass, mock_entry, MOCK_RESULT_RAIN_COMING)
-    state = hass.states.get("binary_sensor.rain_incoming_status")
+    state = hass.states.get("binary_sensor.rain_incoming_imminent")
     assert "confidence" in state.attributes
     assert "frame_count" in state.attributes
 
@@ -312,7 +312,7 @@ async def test_named_location_device_name(hass: HomeAssistant, mock_entry_named)
     await setup_integration(hass, mock_entry_named, MOCK_RESULT_NO_RAIN)
     # Entity IDs use the device name - with a named location
     # the device is "Rain Incoming - Beach House", so entity IDs change
-    state = hass.states.get("binary_sensor.rain_incoming_beach_house_status")
+    state = hass.states.get("binary_sensor.rain_incoming_beach_house_imminent")
     assert state is not None, (
         f"Expected named entity. Available: {[s.entity_id for s in hass.states.async_all()]}"
     )
@@ -322,7 +322,7 @@ async def test_named_location_device_name(hass: HomeAssistant, mock_entry_named)
 async def test_unnamed_location_device_name(hass: HomeAssistant, mock_entry):
     """Entries without location_name still use 'Rain Incoming' device name."""
     await setup_integration(hass, mock_entry, MOCK_RESULT_NO_RAIN)
-    state = hass.states.get("binary_sensor.rain_incoming_status")
+    state = hass.states.get("binary_sensor.rain_incoming_imminent")
     assert state is not None
 
 

--- a/tests/unit/radar/test_detector.py
+++ b/tests/unit/radar/test_detector.py
@@ -283,6 +283,41 @@ class TestTrackedCells:
         assert len(result.tracked_cells) >= 1
 
 
+class TestRainAtLocation:
+    """DetectionResult.rain_at_location distinguishes overhead from approaching."""
+
+    def test_overhead_rain_sets_rain_at_location_true(self):
+        """Rain directly at the location must set rain_at_location=True."""
+        cfg = default_config()
+        grid = np.zeros((64, 64), dtype=np.float32)
+        grid[31:34, 31:34] = 0.9  # rain at centre = at location
+        frames = [make_frame(ts(-20 + i * 10), grid, cfg.analysis_bounds) for i in range(3)]
+        result = detect(frames=frames, location=(LAT, LON), config=cfg)
+        assert result.rain_incoming is True
+        assert result.rain_at_location is True
+
+    def test_approaching_rain_sets_rain_at_location_false(self):
+        """Rain approaching but not yet overhead must set rain_at_location=False."""
+        cfg = default_config()
+        frames = []
+        for i, col_offset in enumerate([18, 22, 26]):
+            grid = np.zeros((64, 64), dtype=np.float32)
+            grid[30:33, col_offset:col_offset + 3] = 0.8
+            frames.append(make_frame(ts(-20 + i * 10), grid, cfg.analysis_bounds))
+        result = detect(frames=frames, location=(LAT, LON), config=cfg)
+        assert result.rain_incoming is True
+        assert result.rain_at_location is False
+
+    def test_no_rain_sets_rain_at_location_false(self):
+        """No rain at all must set rain_at_location=False."""
+        cfg = default_config()
+        grid = np.zeros((64, 64), dtype=np.float32)
+        frames = [make_frame(ts(-20 + i * 10), grid, cfg.analysis_bounds) for i in range(3)]
+        result = detect(frames=frames, location=(LAT, LON), config=cfg)
+        assert result.rain_incoming is False
+        assert result.rain_at_location is False
+
+
 class TestSpeedCap:
     def test_fast_cell_rejected_by_speed_cap(self):
         """A cell moving at 200+ km/h should NOT trigger rain_incoming."""


### PR DESCRIPTION
## Summary

Two binary sensors now serve different use cases:

| Sensor | Display | Triggers when |
|--------|---------|---------------|
| **Status** (existing) | On/Off | Rain is approaching OR overhead |
| **Raining** (new) | Wet/Dry | Rain is at the location right now |

### Why
The MOISTURE device class on Status showed 'Wet' when rain was 45 minutes away - misleading. Now Status shows On/Off (no device class), and the new Raining sensor uses MOISTURE (Wet/Dry) only when rain is actually overhead.

### Changes
- `DetectionResult.rain_at_location` field added (bool, set by existing `_check_rain_at_location` logic)
- `RainIncomingBinarySensor`: removed MOISTURE device class
- `RainingBinarySensor`: new entity, MOISTURE class, reads `rain_at_location`
- README entity reference updated

### TDD
7 new tests (3 detector + 4 integration), all RED before implementation.

### Test plan
- [x] All 451 tests pass