### PR TITLE
Fix retry log format and bump tile retries to 2

### DIFF
--- a/custom_components/rain_incoming/http_retry.py
+++ b/custom_components/rain_incoming/http_retry.py
@@ -144,7 +144,7 @@ async def fetch_with_retry(
                 delay = base_delay * (2 ** attempt)
                 _LOGGER.warning(
                     "Timeout on %s, retrying in %.1fs (attempt %d/%d)",
-                    url, delay, attempt + 1, max_retries,
+                    url, delay, attempt + 1, max_retries + 1,
                 )
                 await asyncio.sleep(delay)
                 continue
@@ -160,7 +160,7 @@ async def fetch_with_retry(
                 _LOGGER.warning(
                     "%s (%d) on %s, retrying in %.1fs (attempt %d/%d)",
                     "Rate limited" if resp.status == 429 else "Server error",
-                    resp.status, url, delay, attempt + 1, max_retries,
+                    resp.status, url, delay, attempt + 1, max_retries + 1,
                 )
                 resp.release()
                 await asyncio.sleep(delay)

--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -221,7 +221,7 @@ async def _fetch_tile(session: aiohttp.ClientSession, url: str) -> Image.Image:
     # than the limit. Holding through resp.read() closes that gap.
     async with _get_tile_semaphore():
         resp = await fetch_with_retry(
-            session, url, max_retries=1, timeout_total=15.0
+            session, url, max_retries=2, timeout_total=15.0
         )
         data = await asyncio.wait_for(resp.read(), timeout=10)
     return Image.open(BytesIO(data)).convert("RGBA")


### PR DESCRIPTION
## Changes

- **Log format**: `attempt 1/1` -> `attempt 1/2` (shows attempt N of total, not attempt N of max_retries)
- **Tile retries**: `max_retries=1` -> `max_retries=2` for radar tile fetches. A single retry wasn't enough for transient tile server slowdowns.

## Context
Observed in prod logs: 5 tiles all timing out simultaneously with `attempt 1/1` which read like the final attempt when it was actually the first retry.

## Test plan
- [x] All 451 tests pass