### PR TITLE
Fix clutter map maturity from 12 hours to 2 weeks (#130)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,7 +234,7 @@ The binary sensor and arrival time sensor expose these attributes for debugging 
 
 ### Cold-start period
 
-The integration learns your local clutter patterns over 12+ hours. During this period you may see slightly reduced accuracy.
+The integration learns your local clutter patterns over approximately 2 weeks. During this period you may see more false positives as the clutter map builds up a baseline of which radar returns are persistent noise vs real precipitation. Accuracy improves gradually as the map matures.
 
 ### False positives
 

--- a/custom_components/rain_incoming/coordinator.py
+++ b/custom_components/rain_incoming/coordinator.py
@@ -74,7 +74,7 @@ FRAMES_TO_FETCH = 8
 # Clutter map persistence
 CLUTTER_MAP_FILENAME = "rain_incoming_clutter.npz"
 CLUTTER_SAVE_INTERVAL = 36  # save every 36 cycles (~6 hours at 10-min intervals)
-CLUTTER_MATURITY_CYCLES = 72  # fully mature after ~12 hours
+CLUTTER_MATURITY_CYCLES = 2016  # fully mature after ~2 weeks at 10-min intervals
 
 
 def _build_analysis_tiles(lat: float, lon: float, zoom: int) -> list[tuple[int, int]]:


### PR DESCRIPTION
## Problem
CLUTTER_MATURITY_CYCLES was 72 (~12 hours). That's one weather pattern. A clutter baseline trained on a single AP event would mark real rain corridors as noise.

## Fix
- `CLUTTER_MATURITY_CYCLES`: 72 -> 2016 (~2 weeks at 10-min polls)
- README cold-start docs updated

The clutter suppression logic (risk of suppressing real rain at clutter-prone locations) remains open in #130.

## Test plan
- [x] All 451 tests pass