### PR TITLE
Add 24-hour TTL to map tile cache (#87)

### DIFF
--- a/custom_components/rain_incoming/radar/composite.py
+++ b/custom_components/rain_incoming/radar/composite.py
@@ -40,11 +40,28 @@ _CROSSHAIR_RADIUS = 8
 _CROSSHAIR_LINE_LENGTH = 16
 _CROSSHAIR_LINE_GAP = 12
 
-# Module-level LRU cache for static map tiles: (style, zoom, x, y) -> RGBA Image
+# Module-level LRU cache for static map tiles: (style, zoom, x, y) -> (RGBA Image, timestamp)
 # Bounded to prevent unbounded memory growth (each tile ~256KB).
 # OrderedDict with move_to_end on access provides true LRU eviction.
-_map_tile_cache: OrderedDict[tuple, Image.Image] = OrderedDict()
+# Entries expire after _MAP_CACHE_TTL_SECONDS to pick up provider tile updates.
+import time as _time_module
+
+_map_tile_cache: OrderedDict[tuple, tuple[Image.Image, float]] = OrderedDict()
 _MAP_CACHE_MAX = 200
+_MAP_CACHE_TTL_SECONDS = 86400  # 24 hours
+
+
+def _get_cached_map_tile(cache_key: tuple) -> Image.Image | None:
+    """Return a cached map tile if present and not expired, else None."""
+    entry = _map_tile_cache.get(cache_key)
+    if entry is None:
+        return None
+    tile, cached_at = entry
+    if _time_module.monotonic() - cached_at > _MAP_CACHE_TTL_SECONDS:
+        del _map_tile_cache[cache_key]
+        return None
+    _map_tile_cache.move_to_end(cache_key)
+    return tile
 
 # Module-level LRU cache for radar tiles: (frame_path, zoom, x, y, scheme) -> RGBA Image
 # The cache key includes frame_path, so stale data can never be served.
@@ -243,9 +260,8 @@ async def _fetch_map_tile(
 
     # Cache key includes style so different styles don't share stale tiles.
     cache_key = (style_def.style, zoom, tx, ty)
-    cached = _map_tile_cache.get(cache_key)  # type: ignore[arg-type]
+    cached = _get_cached_map_tile(cache_key)
     if cached is not None:
-        _map_tile_cache.move_to_end(cache_key)  # type: ignore[arg-type]  # LRU touch
         return cached
 
     # Gate cache-miss fetches through the shared semaphore so map tiles count
@@ -263,7 +279,7 @@ async def _fetch_map_tile(
         tile = ImageEnhance.Color(tile).enhance(1.8)
 
     _evict_map_cache_if_full()
-    _map_tile_cache[cache_key] = tile  # type: ignore[index]
+    _map_tile_cache[cache_key] = (tile, _time_module.monotonic())  # type: ignore[index]
     return tile
 
 

--- a/tests/unit/radar/test_cache_cleanup.py
+++ b/tests/unit/radar/test_cache_cleanup.py
@@ -21,8 +21,9 @@ class TestClearTileCaches:
     """clear_tile_caches must empty both module-level caches."""
 
     def test_clears_both_caches(self):
+        import time
         # Populate caches with dummy data
-        _map_tile_cache[("test", 7, 10, 20)] = Image.new("RGBA", (1, 1))
+        _map_tile_cache[("test", 7, 10, 20)] = (Image.new("RGBA", (1, 1)), time.monotonic())
         _radar_tile_cache[("/v2/radar/x", 7, 10, 20, 2)] = Image.new("RGBA", (1, 1))
 
         assert len(_map_tile_cache) > 0
@@ -48,13 +49,15 @@ class TestMapCacheBounded:
 
     def test_map_cache_evicts_when_full(self):
         """Filling the map cache past _MAP_CACHE_MAX must trigger eviction."""
+        import time
         from custom_components.rain_incoming.radar.composite import _evict_map_cache_if_full
 
         _map_tile_cache.clear()
         try:
             tiny = Image.new("RGBA", (1, 1))
+            now = time.monotonic()
             for i in range(_MAP_CACHE_MAX + 10):
-                _map_tile_cache[("style", 7, i, 0)] = tiny
+                _map_tile_cache[("style", 7, i, 0)] = (tiny, now)
 
             assert len(_map_tile_cache) > _MAP_CACHE_MAX
 
@@ -78,8 +81,9 @@ class TestUnloadClearsCaches:
         from custom_components.rain_incoming import async_unload_entry
         from custom_components.rain_incoming.const import DOMAIN
 
+        import time
         # Populate caches
-        _map_tile_cache[("test", 7, 1, 1)] = Image.new("RGBA", (1, 1))
+        _map_tile_cache[("test", 7, 1, 1)] = (Image.new("RGBA", (1, 1)), time.monotonic())
         _radar_tile_cache[("/v2/radar/x", 7, 1, 1, 2)] = Image.new("RGBA", (1, 1))
 
         hass = MagicMock()

--- a/tests/unit/radar/test_lru_eviction.py
+++ b/tests/unit/radar/test_lru_eviction.py
@@ -23,16 +23,17 @@ class TestMapCacheLRU:
         """A tile accessed recently must not be evicted even if inserted first."""
         _map_tile_cache.clear()
         try:
+            import time
             tiny = Image.new("RGBA", (1, 1))
+            now = time.monotonic()
             # Insert MAX + 10 entries
             for i in range(_MAP_CACHE_MAX + 10):
-                _map_tile_cache[("style", 7, i, 0)] = tiny
+                _map_tile_cache[("style", 7, i, 0)] = (tiny, now)
 
-            # Access the very first entry via the LRU touch pattern used in production:
-            # .get() followed by .move_to_end()
+            # Access the very first entry via the LRU touch pattern used in production
             first_key = ("style", 7, 0, 0)
-            _ = _map_tile_cache.get(first_key)
-            _map_tile_cache.move_to_end(first_key)
+            from custom_components.rain_incoming.radar.composite import _get_cached_map_tile
+            _get_cached_map_tile(first_key)
 
             _evict_map_cache_if_full()
 

--- a/tests/unit/radar/test_map_cache_ttl.py
+++ b/tests/unit/radar/test_map_cache_ttl.py
@@ -1,0 +1,52 @@
+"""Tests for map tile cache TTL expiry (#87).
+
+Map tiles should expire after a configurable TTL so stale tiles from
+provider updates are eventually refreshed.
+"""
+from __future__ import annotations
+
+import time
+from unittest.mock import patch
+
+from PIL import Image
+
+from custom_components.rain_incoming.radar.composite import (
+    _map_tile_cache,
+    _MAP_CACHE_TTL_SECONDS,
+)
+
+
+class TestMapCacheTTL:
+    def test_ttl_constant_is_24_hours(self):
+        assert _MAP_CACHE_TTL_SECONDS == 86400
+
+    def test_expired_entry_treated_as_cache_miss(self):
+        """A map tile older than TTL must not be returned from cache."""
+        _map_tile_cache.clear()
+        try:
+            key = ("voyager", 7, 100, 50)
+            tile = Image.new("RGBA", (1, 1))
+            # Insert with a timestamp in the past (beyond TTL)
+            expired_time = time.monotonic() - _MAP_CACHE_TTL_SECONDS - 1
+            _map_tile_cache[key] = (tile, expired_time)
+
+            from custom_components.rain_incoming.radar.composite import _get_cached_map_tile
+            result = _get_cached_map_tile(key)
+            assert result is None, "Expired tile must not be returned from cache"
+        finally:
+            _map_tile_cache.clear()
+
+    def test_fresh_entry_returned_from_cache(self):
+        """A map tile within TTL must be returned from cache."""
+        _map_tile_cache.clear()
+        try:
+            key = ("voyager", 7, 100, 50)
+            tile = Image.new("RGBA", (1, 1))
+            fresh_time = time.monotonic()
+            _map_tile_cache[key] = (tile, fresh_time)
+
+            from custom_components.rain_incoming.radar.composite import _get_cached_map_tile
+            result = _get_cached_map_tile(key)
+            assert result is tile, "Fresh tile must be returned from cache"
+        finally:
+            _map_tile_cache.clear()


### PR DESCRIPTION
**Closes #87**

## Problem
Map tiles cached indefinitely - stale tiles persist until HA restarts if a provider updates their imagery.

## Fix
- Cache entries now store `(Image, monotonic_timestamp)` tuples
- `_get_cached_map_tile()` returns None for entries older than 24 hours
- Lazy expiry - expired entries deleted on access
- LRU eviction and size limits still apply

## TDD
3 new tests: TTL constant, expired miss, fresh hit. Existing cache tests updated for tuple format.

## Test plan
- [x] All 454 tests pass