### PR TITLE
Count only enabled entries against location limit (#74)

### DIFF
--- a/custom_components/rain_incoming/config_flow.py
+++ b/custom_components/rain_incoming/config_flow.py
@@ -174,7 +174,8 @@ class RainIncomingConfigFlow(ConfigFlow, domain=DOMAIN):
         self, user_input: dict | None = None
     ) -> ConfigFlowResult:
         existing = self.hass.config_entries.async_entries(DOMAIN)
-        if len(existing) >= MAX_LOCATIONS:
+        enabled = [e for e in existing if e.disabled_by is None]
+        if len(enabled) >= MAX_LOCATIONS:
             return self.async_abort(reason="too_many_locations")
 
         errors: dict[str, str] = {}

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -564,6 +564,34 @@ async def test_config_flow_accepts_when_below_location_limit(hass: HomeAssistant
 
 
 @pytest.mark.asyncio
+async def test_config_flow_allows_when_disabled_entries_free_slots(hass: HomeAssistant):
+    """4 entries with 1 disabled = 3 enabled. Should allow a 4th enabled entry."""
+    from homeassistant.config_entries import ConfigEntryDisabler
+
+    for i in range(4):
+        entry = MockConfigEntry(
+            domain=DOMAIN,
+            data={
+                "latitude": float(i),
+                "longitude": float(i),
+                "lookahead_minutes": 60,
+                CONF_MAP_STYLE: "voyager",
+            },
+            version=2,
+            disabled_by=ConfigEntryDisabler.USER if i == 0 else None,
+        )
+        entry.add_to_hass(hass)
+
+    result = await hass.config_entries.flow.async_init(
+        DOMAIN, context={"source": "user"}
+    )
+    assert result["type"] == FlowResultType.FORM, (
+        f"With 1 disabled entry, should allow adding (3 enabled < 4 max). "
+        f"Got: {result['type']}"
+    )
+
+
+@pytest.mark.asyncio
 async def test_config_flow_rejects_when_above_location_limit(hass: HomeAssistant):
     for i in range(5):
         entry = MockConfigEntry(


### PR DESCRIPTION
**Closes #74**

## Problem
Max-locations check counted all entries including disabled ones. Couldn't add a replacement for a disabled location.

## Fix
Filter to `disabled_by is None` before comparing against `MAX_LOCATIONS`.

## TDD
`test_config_flow_allows_when_disabled_entries_free_slots` - 4 entries with 1 disabled = 3 enabled, allows 4th.

## Test plan
- [x] All 39 config flow tests pass
- [x] Full suite passes (452 tests)