### PR TITLE
Expose max_cell_confidence attribute on imminent sensor (#52)

### DIFF
--- a/custom_components/rain_incoming/binary_sensor.py
+++ b/custom_components/rain_incoming/binary_sensor.py
@@ -72,6 +72,9 @@ class RainIncomingBinarySensor(CoordinatorEntity[RainDetectorCoordinator], Binar
         if self.coordinator.data is not None:
             attrs["confidence"] = self.coordinator.data.confidence.value
             attrs["frame_count"] = self.coordinator.data.frame_count
+            cells = self.coordinator.data.tracked_cells
+            if cells:
+                attrs["max_cell_confidence"] = max(c.confidence for c in cells)
         if self.coordinator.last_update_success_time is not None:
             attrs["last_update_success"] = self.coordinator.last_update_success_time.isoformat()
         return attrs

--- a/tests/integration/test_sensors.py
+++ b/tests/integration/test_sensors.py
@@ -283,6 +283,29 @@ async def test_binary_sensor_still_has_dynamic_attributes(hass: HomeAssistant, m
 
 
 @pytest.mark.asyncio
+async def test_binary_sensor_exposes_max_cell_confidence(hass: HomeAssistant, mock_entry):
+    """The imminent sensor must expose the max cell confidence as an attribute."""
+    from custom_components.rain_incoming.radar.detector import TrackedCell
+    result_with_cells = DetectionResult(
+        rain_incoming=True,
+        arrival_time=datetime(2026, 4, 7, 10, 30, tzinfo=timezone.utc),
+        confidence=Confidence.NORMAL,
+        frame_count=6,
+        max_approaching_intensity=0.65,
+        tracked_cells=[
+            TrackedCell(lat=-33.7, lon=151.2, velocity_kmh=40, bearing=180, confidence=0.85),
+            TrackedCell(lat=-33.8, lon=151.3, velocity_kmh=35, bearing=190, confidence=0.72),
+        ],
+    )
+    await setup_integration(hass, mock_entry, result_with_cells)
+    state = hass.states.get("binary_sensor.rain_incoming_imminent")
+    assert "max_cell_confidence" in state.attributes, (
+        "Imminent sensor must expose max_cell_confidence attribute"
+    )
+    assert state.attributes["max_cell_confidence"] == 0.85
+
+
+@pytest.mark.asyncio
 async def test_arrival_sensor_still_has_dynamic_attributes(hass: HomeAssistant, mock_entry):
     await setup_integration(hass, mock_entry, MOCK_RESULT_RAIN_COMING)
     state = hass.states.get("sensor.rain_incoming_arrival_time")


### PR DESCRIPTION
**Closes #52**

## Summary
The imminent binary sensor now exposes `max_cell_confidence` (0.0-1.0) as a state attribute when tracked cells are present. Users can filter automations by confidence, e.g.:

```yaml
condition:
  - condition: template
    value_template: >
      {{ state_attr('binary_sensor.rain_incoming_imminent', 'max_cell_confidence') | float > 0.7 }}
```

## TDD
`test_binary_sensor_exposes_max_cell_confidence` - RED then GREEN.

## Test plan
- [x] All 452 tests pass