### PR TITLE
Add dev volume safety guard (#56)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,10 @@ Assume external dependencies will break. Code must be resilient and observable.
 - **Log enough for users to diagnose.** Include HTTP status, URL or service name, and a human-readable message. Don't log raw tracebacks for expected failure modes.
 - **Fail visible, not silent.** Missing data, empty renders, stale sensors - these must appear in the HA system log, not hide behind debug-level logging.
 
+## Docker volume safety
+
+**Never run `docker compose down -v`, `docker volume rm`, or `docker volume prune` against dev volumes.** These contain HA config, auth tokens, and integration state that take significant time to recreate. Use `make dev-stop` (safe) or `make dev-nuke` (interactive confirmation) instead.
+
 ## Handling unknowns
 
 LLMs are naturally optimistic - bias toward pessimism. If you're unsure about something, say so. If you can verify quickly, do it. If you can't, stop and ask rather than silently assume.

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,14 @@ dev-logs:
 dev-restart:
 	docker compose -f docker-compose.dev.yml down
 	docker compose -f docker-compose.dev.yml up -d
+
+# --- Volume safety ---
+# Prevent accidental deletion of dev HA volumes. These contain config,
+# auth tokens, and integration state that take time to recreate.
+
+dev-nuke:
+	@echo "WARNING: This will DELETE all HA dev data (config, auth, integrations)."
+	@echo "Volume: ha-dev-config"
+	@read -p "Type 'yes' to confirm: " confirm && [ "$$confirm" = "yes" ] || (echo "Aborted."; exit 1)
+	docker compose -f docker-compose.dev.yml down -v
+	@echo "Dev volumes removed. Run 'make dev' to start fresh."


### PR DESCRIPTION
**Closes #56**

## Changes
- `make dev-nuke`: new target with interactive confirmation for volume deletion
- CLAUDE.md: explicit prohibition on destructive docker volume commands

## Why
AI agents can accidentally run `docker compose down -v` or `docker volume rm`, destroying HA dev config, auth tokens, and integration state. The safe targets (`dev-stop`, `dev-restart`) never touch volumes. The new `dev-nuke` requires typing 'yes' to confirm.

No code changes, no tests needed.