### PR TITLE
Fix #144: per-location render lock replaces global lock

### DIFF
--- a/custom_components/rain_incoming/image.py
+++ b/custom_components/rain_incoming/image.py
@@ -28,25 +28,31 @@ from .radar.composite import render_animated_composite
 # and return a broken-image icon.
 _RENDER_TIMEOUT_SECONDS = 55.0
 
-# Global lock: only one render runs at a time across all radius entities.
-# Multiple radii (64/128/256km) all fire when the coordinator updates. Without
-# this lock they compete simultaneously for tile connections, multiplying peak
-# load by the number of radii and causing HA-wide lockups when tiles are slow.
-_render_lock: asyncio.Lock | None = None
+# Render locks: one per coordinator (config entry), keyed by entry_id.
+# Multiple radii (64/128/256km) for the SAME location serialize behind one
+# lock to prevent tile fetch storms. Different locations render in parallel -
+# a global lock starved 256km entities when multiple locations were configured
+# (#144).
+_render_locks: dict[str, asyncio.Lock] = {}
 
 
-def _get_render_lock() -> asyncio.Lock:
-    """Lazily create the render lock (must be called inside a running event loop)."""
-    global _render_lock
-    if _render_lock is None:
-        _render_lock = asyncio.Lock()
-    return _render_lock
+def _get_render_lock(entry_id: str) -> asyncio.Lock:
+    """Get or create the render lock for a config entry."""
+    if entry_id not in _render_locks:
+        _render_locks[entry_id] = asyncio.Lock()
+    return _render_locks[entry_id]
 
 
-def reset_render_lock() -> None:
-    """Reset the render lock. Called when the last config entry is unloaded."""
-    global _render_lock
-    _render_lock = None
+def reset_render_lock(entry_id: str | None = None) -> None:
+    """Reset render lock(s). Called when a config entry is unloaded.
+
+    If entry_id is provided, removes just that entry's lock.
+    If None, removes all locks (backward compat for last-entry-unload).
+    """
+    if entry_id is not None:
+        _render_locks.pop(entry_id, None)
+    else:
+        _render_locks.clear()
 
 
 async def async_setup_entry(
@@ -123,6 +129,10 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
     def _schedule_render(self) -> None:
         """Start a background render task if one isn't already running."""
         if self._render_task is not None and not self._render_task.done():
+            _LOGGER.debug(
+                "Radar %dkm: render already in progress, skipping",
+                self._radius_km,
+            )
             return
         self._render_task = self.hass.async_create_task(
             self._render_to_cache(),
@@ -139,13 +149,21 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
         """
         frame_path = self.coordinator.latest_frame_path
         if frame_path is None:
-            return  # nothing to render yet
+            _LOGGER.info(
+                "Radar %dkm: coordinator has no frame data yet, skipping render",
+                self._radius_km,
+            )
+            return
 
         if frame_path == self._cached_frame_path and self._cached_image is not None:
             return  # already cached this frame
 
         frame_paths = self.coordinator.frame_paths
         if not frame_paths:
+            _LOGGER.warning(
+                "Radar %dkm: coordinator has latest_frame_path but no frame_paths list",
+                self._radius_km,
+            )
             return
 
         data = self._entry.data
@@ -171,7 +189,7 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
         )
 
         try:
-            async with _get_render_lock():
+            async with _get_render_lock(self._entry.entry_id):
                 result = await asyncio.wait_for(
                     render_animated_composite(
                         lat=lat,
@@ -256,11 +274,25 @@ class RadarImageEntity(CoordinatorEntity[RainDetectorCoordinator], ImageEntity):
         exceeding HA's ~60s image_proxy timeout.
         """
         if self._cached_image is None and self._render_task is not None and not self._render_task.done():
+            _LOGGER.debug(
+                "Radar %dkm: cache empty, awaiting in-flight render task",
+                self._radius_km,
+            )
             try:
                 await self._render_task
             except Exception:
-                pass  # _render_to_cache already logs the error
+                _LOGGER.warning(
+                    "Radar %dkm: render task failed while async_image was waiting",
+                    self._radius_km, exc_info=True,
+                )
         if self._cached_image is not None:
             return self._cached_image
-        _LOGGER.debug("Radar %dkm: returning placeholder (cache not yet populated)", self._radius_km)
+        _LOGGER.warning(
+            "Radar %dkm: serving placeholder - no cached image available "
+            "(coordinator.latest_frame_path=%s, render_task=%s)",
+            self._radius_km,
+            self.coordinator.latest_frame_path,
+            "running" if self._render_task and not self._render_task.done()
+            else "done" if self._render_task else "none",
+        )
         return self._make_placeholder()

--- a/tests/integration/test_image_entity.py
+++ b/tests/integration/test_image_entity.py
@@ -452,25 +452,35 @@ class TestRenderTaskCancelledOnEntityRemoval:
 
 
 # ---------------------------------------------------------------------------
-# Fix 2: Concurrent renders across radii must be serialized
+# Fix 2: Concurrent renders across radii must be serialized PER LOCATION
 # ---------------------------------------------------------------------------
 
 class TestRenderSerialization:
-    """Render tasks across different radius entities must not run concurrently.
+    """Render tasks for the SAME location must not run concurrently.
 
     With 3 radii (64, 128, 256km), all render tasks fire when the coordinator
-    updates. Without a global lock they run simultaneously, multiplying
+    updates. Without serialization they run simultaneously, multiplying
     connection load by 3x and causing HA-wide lockups when tiles are slow.
 
-    Fix: a module-level asyncio.Lock ensures only one render runs at a time.
+    Fix: a per-coordinator asyncio.Lock serializes renders within one
+    location. Different locations can render in parallel (#144).
     """
 
     @pytest.mark.asyncio
-    async def test_concurrent_renders_across_radii_are_serialized(self):
-        """Two _render_to_cache calls must not execute render_animated_composite
-        simultaneously — the second must wait for the first to complete."""
-        entity_128 = _make_entity()
-        entity_256 = _make_entity()  # different radius, same coordinator update
+    async def test_same_location_renders_are_serialized(self):
+        """Two _render_to_cache calls for the same coordinator must not
+        execute render_animated_composite simultaneously."""
+        coord = _make_coordinator()
+        entry = _make_entry()
+        entity_128 = RadarImageEntity(coord, entry, 128)
+        entity_256 = RadarImageEntity(coord, entry, 256)
+
+        hass = MagicMock()
+        hass.config.latitude = -33.7
+        hass.config.longitude = 151.2
+        hass.config.time_zone = "Australia/Sydney"
+        entity_128.hass = hass
+        entity_256.hass = hass
 
         concurrent_count = 0
         max_concurrent = 0
@@ -479,7 +489,7 @@ class TestRenderSerialization:
             nonlocal concurrent_count, max_concurrent
             concurrent_count += 1
             max_concurrent = max(max_concurrent, concurrent_count)
-            await asyncio.sleep(0.02)  # simulate non-trivial render work
+            await asyncio.sleep(0.02)
             concurrent_count -= 1
             return b"GIF89a_test"
 
@@ -499,8 +509,61 @@ class TestRenderSerialization:
             )
 
         assert max_concurrent == 1, (
-            f"Renders ran concurrently (max={max_concurrent}). "
-            "A global render lock must serialize renders across all radius entities."
+            f"Same-location renders ran concurrently (max={max_concurrent}). "
+            "Per-coordinator render lock must serialize renders within one location."
+        )
+
+    @pytest.mark.asyncio
+    async def test_different_locations_render_in_parallel(self):
+        """Two _render_to_cache calls for DIFFERENT coordinators must run
+        concurrently. The global lock previously starved 256km entities
+        when multiple locations were configured (#144)."""
+        coord_a = _make_coordinator()
+        coord_b = _make_coordinator()
+        entry_a = _make_entry()
+        entry_b = MagicMock()
+        entry_b.data = {"latitude": -37.8, "longitude": 144.9}
+        entry_b.entry_id = "test_entry_b"
+
+        entity_a = RadarImageEntity(coord_a, entry_a, 128)
+        entity_b = RadarImageEntity(coord_b, entry_b, 128)
+
+        hass = MagicMock()
+        hass.config.latitude = -33.7
+        hass.config.longitude = 151.2
+        hass.config.time_zone = "Australia/Sydney"
+        entity_a.hass = hass
+        entity_b.hass = hass
+
+        concurrent_count = 0
+        max_concurrent = 0
+
+        async def tracked_render(*args, **kwargs):
+            nonlocal concurrent_count, max_concurrent
+            concurrent_count += 1
+            max_concurrent = max(max_concurrent, concurrent_count)
+            await asyncio.sleep(0.02)
+            concurrent_count -= 1
+            return b"GIF89a_test"
+
+        with (
+            patch(
+                "custom_components.rain_incoming.image.render_animated_composite",
+                new=tracked_render,
+            ),
+            patch(
+                "custom_components.rain_incoming.image.async_get_clientsession",
+                return_value=MagicMock(),
+            ),
+        ):
+            await asyncio.gather(
+                entity_a._render_to_cache(),
+                entity_b._render_to_cache(),
+            )
+
+        assert max_concurrent == 2, (
+            f"Different-location renders did not run in parallel (max={max_concurrent}). "
+            "Per-coordinator locks must allow different locations to render concurrently."
         )
 
 

--- a/tests/unit/radar/test_cache_cleanup.py
+++ b/tests/unit/radar/test_cache_cleanup.py
@@ -123,13 +123,19 @@ class TestAsyncPrimitivesResetOnClear:
     def test_render_lock_reset_on_clear(self):
         import custom_components.rain_incoming.image as img_mod
 
-        # Force creation
-        img_mod._get_render_lock()
-        assert img_mod._render_lock is not None
+        # Force creation for two entries
+        img_mod._get_render_lock("entry_a")
+        img_mod._get_render_lock("entry_b")
+        assert len(img_mod._render_locks) == 2
 
+        # Reset specific entry
         from custom_components.rain_incoming.image import reset_render_lock
-        reset_render_lock()
+        reset_render_lock("entry_a")
+        assert "entry_a" not in img_mod._render_locks
+        assert "entry_b" in img_mod._render_locks
 
-        assert img_mod._render_lock is None, (
-            "Render lock must be reset to None after reset_render_lock"
+        # Reset all (last entry unload)
+        reset_render_lock()
+        assert len(img_mod._render_locks) == 0, (
+            "Render locks must be cleared after reset_render_lock()"
         )


### PR DESCRIPTION
## Summary

The global asyncio.Lock serialized all 9 image entities (3 locations x 3 radii) behind one lock. 256km renders consistently starved - they queued behind 64km and 128km for all locations and never completed before the next coordinator cycle.

**Fix:** Per-coordinator render lock keyed by `entry_id`. Each location's 3 radii still serialize (preventing tile fetch storms), but different locations render in parallel.

Also adds observability to the render pipeline:
- WARNING when serving placeholder (with coordinator state)
- WARNING when render task fails during async_image
- INFO when coordinator has no frame data (startup transient)
- DEBUG when render skipped (task already in progress)

## Test plan
- [x] 496 tests pass locally
- [x] `test_same_location_renders_are_serialized` - same-location radii still serialize
- [x] `test_different_locations_render_in_parallel` - different locations now render concurrently
- [x] `test_render_lock_reset_on_clear` - per-entry lock cleanup works
- [ ] CI passes
- [ ] Manual: drop image.py on prod HA, verify all 9 images render after restart

Closes #144

🤖 Generated with [Claude Code](https://claude.com/claude-code)