### PR TITLE
Cache frames in verifier: 7.0s -> 1.2s (5.8x faster)

### DIFF
--- a/scripts/backtest/verifier.py
+++ b/scripts/backtest/verifier.py
@@ -47,6 +47,16 @@ class FutureRadarVerifier:
     ) -> None:
         self._captures = sorted(captures, key=lambda c: c.frame_ts)
         self._config = config or VerifierConfig()
+        # Pre-build frames once so _rain_at_location reuses them across
+        # predictions instead of re-decoding tile PNGs for every check.
+        self._frame_cache: dict[int, CapturedRadarFrame] = {
+            c.frame_ts: CapturedRadarFrame(
+                _timestamp=datetime.fromtimestamp(c.frame_ts, tz=timezone.utc),
+                _tile_paths=c.tile_paths,
+                _zoom=c.zoom,
+            )
+            for c in self._captures
+        }
 
     def verify(self, predictions: list[PredictionRecord]) -> list[VerificationRecord]:
         """Verify each prediction against future radar captures."""
@@ -84,11 +94,7 @@ class FutureRadarVerifier:
         """Return True if any future capture shows rain in the location neighborhood."""
         config = self._config
         bounds = _build_analysis_bounds(capture)
-        frame = CapturedRadarFrame(
-            _timestamp=datetime.fromtimestamp(capture.frame_ts, tz=timezone.utc),
-            _tile_paths=capture.tile_paths,
-            _zoom=capture.zoom,
-        )
+        frame = self._frame_cache[capture.frame_ts]
         grid = frame.get_intensity_grid(bounds, _GRID_SIZE, _GRID_SIZE)
 
         loc_row, loc_col = _location_pixel(capture.lat, capture.lon, bounds, _GRID_SIZE)

--- a/tests/unit/backtest/test_verifier.py
+++ b/tests/unit/backtest/test_verifier.py
@@ -669,3 +669,66 @@ class TestVerifyProximityCheck:
         # Second prediction: dry capture at BASE_TS+2400 is within its lookahead
         # (BASE_TS+1800 + 1200 = BASE_TS+3000), and it's dry
         assert result[1].actual_rain is False
+
+
+# ---------------------------------------------------------------------------
+# Frame caching: verifier must not rebuild frames for the same capture
+# ---------------------------------------------------------------------------
+
+
+class TestVerifierFrameCaching:
+    """The verifier checks multiple predictions against the same future captures.
+    Without caching, _rain_at_location builds a new CapturedRadarFrame for each
+    check, re-decoding tile PNGs repeatedly."""
+
+    def test_captured_frame_built_once_per_unique_capture(self, tmp_path):
+        """CapturedRadarFrame must be created at most once per unique capture,
+        not once per _rain_at_location call."""
+        from unittest.mock import patch as mock_patch
+        from scripts.backtest.verifier import FutureRadarVerifier, VerifierConfig
+        from scripts.backtest.captured_frame import CapturedRadarFrame
+
+        # Create 3 dry captures with transparent tile PNGs
+        tile_bytes = _make_transparent_tile_png()
+        captures = []
+        for i in range(3):
+            ts = _BASE_TS + i * 600
+            tile_dir = tmp_path / str(ts)
+            tile_dir.mkdir()
+            tile_paths = {}
+            for tx, ty in _ANALYSIS_TILES:
+                path = tile_dir / f"7_{tx}_{ty}_s2.png"
+                path.write_bytes(tile_bytes)
+                tile_paths[(tx, ty)] = path
+            captures.append(_make_capture(ts, tile_paths))
+
+        # 2 predictions that both look at overlapping future captures
+        predictions = [
+            PredictionRecord(
+                window_end_ts=_BASE_TS,  # looks at captures 0,1,2
+                rain_incoming=True, rain_at_location=False,
+                arrival_minutes=30.0, confidence="normal",
+                cell_count=1, max_intensity=0.5,
+            ),
+            PredictionRecord(
+                window_end_ts=_BASE_TS + 600,  # looks at captures 1,2
+                rain_incoming=True, rain_at_location=False,
+                arrival_minutes=30.0, confidence="normal",
+                cell_count=1, max_intensity=0.5,
+            ),
+        ]
+        config = VerifierConfig(lookahead_seconds=1800)
+
+        with mock_patch(
+            "scripts.backtest.verifier.CapturedRadarFrame",
+            wraps=CapturedRadarFrame,
+        ) as mock_frame_cls:
+            verifier = FutureRadarVerifier(captures, config)
+            verifier.verify(predictions)
+
+        # With caching: each capture constructed at most once in __init__ = 3
+        # Without caching: capture 1 and 2 checked by both predictions = 5
+        assert mock_frame_cls.call_count <= len(captures), (
+            f"CapturedRadarFrame constructed {mock_frame_cls.call_count} times "
+            f"for {len(captures)} captures - frames not being cached"
+        )


### PR DESCRIPTION
## Summary

Same fix as #148 (replay frame cache), applied to the verifier. `FutureRadarVerifier._rain_at_location` was building a new `CapturedRadarFrame` for every future capture check. With 280 checks across 43 predictions (50 captures), tile PNGs were decoded repeatedly.

Fix: pre-build frames once in `__init__` keyed by `frame_ts`, reuse via `get_intensity_grid` cache.

| Metric | Before | After |
|--------|--------|-------|
| Time (50 captures, 43 predictions) | 7.0s | 1.2s |
| CapturedRadarFrame constructions | 280 | 50 (one per capture) |

Combined with the replay cache (#148), a full Darwin run should drop from ~10min to ~2-3min.

TDD: test written first (RED), then fixed (GREEN).

## Test plan
- [x] 595 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)