### PR TITLE
Backtesting Phase 1C: CSV and markdown report output

### DIFF
--- a/scripts/backtest/cli.py
+++ b/scripts/backtest/cli.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from scripts.backtest.data_loader import load_captures
 from scripts.backtest.metrics import ScoreCard, VerificationRecord, compute_scorecard
 from scripts.backtest.replay import ReplayConfig, ReplayEngine
+from scripts.backtest.report import write_scorecard_markdown, write_verification_csv
 from scripts.backtest.verifier import FutureRadarVerifier
 
 
@@ -105,6 +106,12 @@ def main(argv: list[str] | None = None) -> None:
         default=False,
         help="With --verify, list individual misses and false alarms with timestamps",
     )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="With --verify, write CSV and markdown reports to this directory",
+    )
 
     args = parser.parse_args(argv)
 
@@ -130,6 +137,8 @@ def main(argv: list[str] | None = None) -> None:
         lookahead_seconds=args.lookahead_minutes * 60,
     )
     engine = ReplayEngine(config)
+    all_scorecards: list[ScoreCard] = []
+    all_records: dict[str, list[VerificationRecord]] = {}
 
     for loc_dir in location_dirs:
         location_name = loc_dir.name
@@ -151,6 +160,8 @@ def main(argv: list[str] | None = None) -> None:
             _print_scorecard(scorecard)
             if args.dump_errors:
                 _print_errors(records)
+            all_scorecards.append(scorecard)
+            all_records[location_name] = records
         else:
             total = len(predictions)
             if total:
@@ -169,3 +180,11 @@ def main(argv: list[str] | None = None) -> None:
                     f"at_loc={p.rain_at_location} arrival={arrival} "
                     f"cells={p.cell_count} conf={p.confidence}"
                 )
+
+    # Write reports if --output-dir and --verify were both specified
+    if args.output_dir and all_scorecards:
+        args.output_dir.mkdir(parents=True, exist_ok=True)
+        for location_name, records in all_records.items():
+            write_verification_csv(records, location_name, args.output_dir / f"{location_name}.csv")
+        write_scorecard_markdown(all_scorecards, args.output_dir / "scorecard.md")
+        print(f"\nReports written to {args.output_dir}")

--- a/scripts/backtest/report.py
+++ b/scripts/backtest/report.py
@@ -1,0 +1,73 @@
+"""Report generation for the backtesting framework.
+
+Writes CSV verification records and markdown scorecards.
+"""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from scripts.backtest.metrics import ScoreCard, VerificationRecord
+
+
+_CSV_FIELDS = [
+    "location",
+    "window_end_ts",
+    "predicted_rain",
+    "actual_rain",
+    "predicted_arrival_minutes",
+    "actual_arrival_minutes",
+]
+
+
+def write_verification_csv(
+    records: list[VerificationRecord],
+    location: str,
+    path: Path,
+) -> None:
+    """Write verification records to a CSV file."""
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=_CSV_FIELDS)
+        writer.writeheader()
+        for r in records:
+            writer.writerow({
+                "location": location,
+                "window_end_ts": r.window_end_ts,
+                "predicted_rain": r.predicted_rain,
+                "actual_rain": r.actual_rain,
+                "predicted_arrival_minutes": r.predicted_arrival_minutes if r.predicted_arrival_minutes is not None else "",
+                "actual_arrival_minutes": r.actual_arrival_minutes if r.actual_arrival_minutes is not None else "",
+            })
+
+
+def write_scorecard_markdown(
+    scorecards: list[ScoreCard],
+    path: Path,
+) -> None:
+    """Write a markdown report with per-location scorecards."""
+    lines = ["# Backtest Results", ""]
+
+    lines.append("| Location | Windows | POD | FAR | CSI | Bias | Hits | Misses | FA | CN |")
+    lines.append("|----------|---------|-----|-----|-----|------|------|--------|----|----|")
+
+    for sc in scorecards:
+        ct = sc.contingency
+        lines.append(
+            f"| {sc.location} | {sc.total_windows} "
+            f"| {sc.pod:.3f} | {sc.far:.3f} | {sc.csi:.3f} | {sc.bias:.2f} "
+            f"| {ct.hits} | {ct.misses} | {ct.false_alarms} | {ct.correct_negatives} |"
+        )
+
+    # Lead time summary per location
+    lines.extend(["", "## Lead Time Errors", ""])
+    for sc in scorecards:
+        mean = sc.mean_lead_time_error
+        median = sc.median_lead_time_error
+        if mean is not None and median is not None:
+            n = len(sc.lead_time_errors)
+            lines.append(f"- **{sc.location}**: mean={mean:.1f}min, median={median:.1f}min (n={n})")
+        else:
+            lines.append(f"- **{sc.location}**: no verified arrival times")
+
+    lines.append("")
+    path.write_text("\n".join(lines))

--- a/tests/unit/backtest/test_cli.py
+++ b/tests/unit/backtest/test_cli.py
@@ -475,3 +475,49 @@ class TestDumpErrors:
         captured = capsys.readouterr()
         # Should not crash, should not print error sections
         assert "MISSES" not in captured.out
+
+
+# ---------------------------------------------------------------------------
+# Test: --output-dir writes CSV and markdown files
+# ---------------------------------------------------------------------------
+
+
+class TestOutputDir:
+    def test_output_dir_creates_csv_and_markdown(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """--verify --output-dir must write CSV and markdown scorecard."""
+        from scripts.backtest.cli import main
+        from scripts.backtest.metrics import (
+            ContingencyTable, ScoreCard, VerificationRecord,
+        )
+
+        data_dir = tmp_path / "data"
+        captures_dir = data_dir / "captures"
+        _make_location_dir(captures_dir, "test_loc")
+
+        output_dir = tmp_path / "reports"
+
+        records = [
+            VerificationRecord(window_end_ts=1000, predicted_rain=True, actual_rain=True),
+        ]
+        scorecard = ScoreCard(
+            location="test_loc",
+            contingency=ContingencyTable(hits=1),
+            total_windows=1,
+            skipped_gaps=0,
+            lead_time_errors=[],
+        )
+
+        with patch("scripts.backtest.cli.ReplayEngine") as MockEngine, \
+             patch("scripts.backtest.cli.FutureRadarVerifier") as MockVerifier, \
+             patch("scripts.backtest.cli.compute_scorecard", return_value=scorecard):
+            instance = MockEngine.return_value
+            instance.replay.return_value = [MagicMock()]
+            verifier_instance = MockVerifier.return_value
+            verifier_instance.verify.return_value = records
+
+            main(["--data-dir", str(data_dir), "--verify", "--output-dir", str(output_dir)])
+
+        assert (output_dir / "test_loc.csv").exists(), "CSV file not created"
+        assert (output_dir / "scorecard.md").exists(), "Markdown scorecard not created"

--- a/tests/unit/backtest/test_report.py
+++ b/tests/unit/backtest/test_report.py
@@ -1,0 +1,104 @@
+"""Unit tests for scripts.backtest.report - CSV and markdown report generation."""
+from __future__ import annotations
+
+import csv
+from io import StringIO
+from pathlib import Path
+
+import pytest
+
+from scripts.backtest.metrics import (
+    ContingencyTable,
+    ScoreCard,
+    VerificationRecord,
+)
+
+
+def _make_records() -> list[VerificationRecord]:
+    return [
+        VerificationRecord(window_end_ts=1000, predicted_rain=True, actual_rain=True,
+                           predicted_arrival_minutes=30.0, actual_arrival_minutes=25.0),
+        VerificationRecord(window_end_ts=2000, predicted_rain=False, actual_rain=True,
+                           actual_arrival_minutes=10.0),
+        VerificationRecord(window_end_ts=3000, predicted_rain=True, actual_rain=False,
+                           predicted_arrival_minutes=45.0),
+        VerificationRecord(window_end_ts=4000, predicted_rain=False, actual_rain=False),
+    ]
+
+
+class TestWriteVerificationCsv:
+    def test_csv_has_header_and_data_rows(self, tmp_path):
+        """CSV must have a header row plus one row per record."""
+        from scripts.backtest.report import write_verification_csv
+
+        records = _make_records()
+        csv_path = tmp_path / "results.csv"
+        write_verification_csv(records, "darwin", csv_path)
+
+        lines = csv_path.read_text().splitlines()
+        assert len(lines) == 5  # 1 header + 4 records
+
+        reader = csv.DictReader(StringIO(csv_path.read_text()))
+        rows = list(reader)
+        assert len(rows) == 4
+        assert rows[0]["location"] == "darwin"
+        assert rows[0]["window_end_ts"] == "1000"
+        assert rows[0]["predicted_rain"] == "True"
+        assert rows[0]["actual_rain"] == "True"
+        assert rows[0]["predicted_arrival_minutes"] == "30.0"
+        assert rows[0]["actual_arrival_minutes"] == "25.0"
+
+    def test_csv_none_values_are_empty(self, tmp_path):
+        """None arrival times should be empty strings in CSV, not 'None'."""
+        from scripts.backtest.report import write_verification_csv
+
+        records = [VerificationRecord(window_end_ts=1000, predicted_rain=False, actual_rain=False)]
+        csv_path = tmp_path / "results.csv"
+        write_verification_csv(records, "test", csv_path)
+
+        reader = csv.DictReader(StringIO(csv_path.read_text()))
+        row = next(reader)
+        assert row["predicted_arrival_minutes"] == ""
+        assert row["actual_arrival_minutes"] == ""
+
+
+class TestWriteMarkdownScorecard:
+    def test_scorecard_contains_metrics(self, tmp_path):
+        """Markdown scorecard must contain POD, FAR, CSI, Bias and contingency table."""
+        from scripts.backtest.report import write_scorecard_markdown
+
+        scorecard = ScoreCard(
+            location="darwin",
+            contingency=ContingencyTable(hits=99, misses=33, false_alarms=129, correct_negatives=627),
+            total_windows=916,
+            skipped_gaps=28,
+            lead_time_errors=[-7.0, 0.0, 5.0],
+        )
+        md_path = tmp_path / "scorecard.md"
+        write_scorecard_markdown([scorecard], md_path)
+
+        content = md_path.read_text()
+        assert "darwin" in content
+        assert "POD" in content
+        assert "FAR" in content
+        assert "CSI" in content
+        assert "99" in content  # hits
+        assert "33" in content  # misses
+        assert "129" in content  # false alarms
+
+    def test_multiple_locations_in_scorecard(self, tmp_path):
+        """Scorecard with multiple locations should include all of them."""
+        from scripts.backtest.report import write_scorecard_markdown
+
+        scorecards = [
+            ScoreCard(location="darwin", contingency=ContingencyTable(hits=10),
+                      total_windows=20, skipped_gaps=0, lead_time_errors=[]),
+            ScoreCard(location="cairns", contingency=ContingencyTable(hits=5),
+                      total_windows=15, skipped_gaps=0, lead_time_errors=[]),
+        ]
+        md_path = tmp_path / "scorecard.md"
+        write_scorecard_markdown(scorecards, md_path)
+
+        content = md_path.read_text()
+        assert "darwin" in content
+        assert "cairns" in content


### PR DESCRIPTION
## Summary

Phase 1C - report generation for the backtesting framework.

### New flag: `--output-dir`

```bash
python -m scripts.backtest --data-dir ./backtest_data \
  --locations all --qc none --verify \
  --output-dir reports/baseline
```

Writes:
- `{location}.csv` per location - every prediction + verification outcome
- `scorecard.md` - all locations in a single markdown table

### CSV format
```
location,window_end_ts,predicted_rain,actual_rain,predicted_arrival_minutes,actual_arrival_minutes
darwin,1776345600,False,True,,50.0
darwin,1776349200,True,False,30.0,
```

### Markdown format
| Location | Windows | POD | FAR | CSI | Bias | Hits | Misses | FA | CN |
|----------|---------|-----|-----|-----|------|------|--------|----|----|
| darwin | 916 | 0.750 | 0.566 | 0.379 | 1.73 | 99 | 33 | 129 | 627 |

### Not in this PR
- `--compare` (load previous run's CSV, show deltas) - follow-up
- JSONL investigations file - follow-up after first full baseline run

5 new tests (TDD). 600 total.

## Test plan
- [x] 600 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)