### PR TITLE
Add --compare flag and JSON scorecard output (Phase 2A)

### DIFF
--- a/docs/backtest-investigations.md
+++ b/docs/backtest-investigations.md
@@ -1,0 +1,72 @@
+# Backtest Investigations
+
+Baseline run: 2026-04-24, 10 days of data, 8 locations, `--qc none`.
+
+## Baseline Results
+
+| Location | POD | FAR | CSI | Bias | Hits | Misses | FA | CN |
+|----------|-----|-----|-----|------|------|--------|----|----|
+| cairns_babinda | 0.972 | 0.052 | 0.923 | 1.02 | 827 | 24 | 45 | 361 |
+| lake_margaret | 0.916 | 0.130 | 0.806 | 1.05 | 241 | 22 | 36 | 958 |
+| quillayute | 0.939 | 0.388 | 0.588 | 1.53 | 413 | 27 | 262 | 555 |
+| hilo | 0.860 | 0.263 | 0.658 | 1.17 | 154 | 25 | 55 | 1023 |
+| mobile | 0.820 | 0.380 | 0.546 | 1.32 | 201 | 44 | 123 | 889 |
+| darwin | 0.810 | 0.571 | 0.390 | 1.89 | 149 | 35 | 198 | 875 |
+| penrith | 0.649 | 0.523 | 0.379 | 1.36 | 135 | 73 | 148 | 901 |
+| ketchikan | - | - | 1.000 | 0.00 | 0 | 0 | 0 | 1257 |
+
+## Key Findings
+
+- Detection is good (POD 0.65-0.97) but false alarms are the main problem (FAR 0.05-0.57)
+- Over-prediction everywhere (Bias > 1.0 at all rain locations)
+- Tropical/maritime locations (Cairns, Hilo) outperform terrain-affected locations (Penrith, Darwin)
+- Lead time errors consistently negative (late predictions, mean -4.6 to -12.0min)
+
+## Investigation Queue
+
+### Priority 1: Rerun with --qc full
+Baseline was `--qc none`. The QC pipeline (texture, temporal, clutter) exists to filter noise. Many "overhead noise" false alarms (predicted arrival 0/-10min) should be suppressed by QC. Compare against baseline to measure QC impact on FAR.
+
+### Priority 2: Detection vs verification proximity mismatch
+The detector uses 128km proximity radius. The verifier uses a 10x10 pixel neighborhood (~30km). A cell 80km away triggers rain_incoming but falls outside the verifier's check, creating phantom false alarms. Need to align these or track them separately.
+
+### Priority 3: False alarm categories
+From Darwin's 129 false alarms:
+- **Overhead noise (~30-40)**: predicted arrival 0min or -10min. Detector says "rain here now" but verifier disagrees. Likely ground clutter or near-miss cells.
+- **Rain that never arrived (~60-70)**: predicted arrival 30-60min. Real approaching cells that dissipated before reaching location. Causes: virga, topographic effects, cell splitting/dying.
+- **Near-miss cells (~20-30)**: predicted arrival 10-25min. Cells that passed nearby but not overhead.
+
+### Priority 4: Penrith deep-dive
+Worst performer (POD 0.649, FAR 0.523, lead time -12min). Near Blue Mountains - user reports rain approaching from west frequently dissipates before arriving at near-sea-level location. Topographic effects need terrain-aware detection.
+
+### Priority 5: Ketchikan anomaly
+Zero rain detected in 10 days at one of the wettest US cities. Possible causes:
+- RainViewer coverage gap at 55N latitude
+- Tile data present but no precipitation colours (different radar network)
+- Genuine dry spell (unlikely for 10 days)
+
+### Priority 6: Miss pattern analysis
+Misses cluster in runs of 5-6 consecutive 10-min windows with descending arrival times (50, 40, 30, 20, 10min). Rain was steadily approaching but detector didn't report it. Possible causes:
+- Cells entering from outside analysis area
+- Below intensity threshold during approach, strengthening on arrival
+- Cell tracking losing the cell between frames
+
+### Priority 7: Lead time model
+Constant-velocity cell projection assumption fails near terrain. Cells accelerate/decelerate. Penrith lead time error mean=-12min (worst) supports this. Consider:
+- Acceleration-aware velocity estimation
+- Historical velocity profiles per location
+- Terrain-weighted arrival time adjustment
+
+## Framework Improvements Needed
+
+### Compare feature
+`--compare <previous-dir>` to show POD/FAR/CSI deltas between runs. Save scorecards as JSON alongside markdown for machine-readable comparison.
+
+### Subset/tagging
+`--max-captures N` for quick iteration (~200 captures = ~1.5 days). Full run for significant changes. Tag output dirs meaningfully: `reports/baseline-qc-none`, `reports/qc-full`.
+
+### Verifier performance
+Quillayute (100% rain) took ~25min to verify. Verifier needs binary search or index for future capture lookup instead of linear scan.
+
+### Dry window skip
+Consecutive dry windows with unchanged latest frame produce identical detection results. Skip detection when the new frame is also dry - major speedup for locations with long dry periods.

--- a/scripts/backtest/cli.py
+++ b/scripts/backtest/cli.py
@@ -14,7 +14,13 @@ from pathlib import Path
 from scripts.backtest.data_loader import load_captures
 from scripts.backtest.metrics import ScoreCard, VerificationRecord, compute_scorecard
 from scripts.backtest.replay import ReplayConfig, ReplayEngine
-from scripts.backtest.report import write_scorecard_markdown, write_verification_csv
+from scripts.backtest.report import (
+    compare_scorecards,
+    load_scorecard_json,
+    write_scorecard_json,
+    write_scorecard_markdown,
+    write_verification_csv,
+)
 from scripts.backtest.verifier import FutureRadarVerifier
 
 
@@ -112,6 +118,12 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="With --verify, write CSV and markdown reports to this directory",
     )
+    parser.add_argument(
+        "--compare",
+        type=Path,
+        default=None,
+        help="Compare against a previous run's output directory (requires scorecards.json)",
+    )
 
     args = parser.parse_args(argv)
 
@@ -187,4 +199,14 @@ def main(argv: list[str] | None = None) -> None:
         for location_name, records in all_records.items():
             write_verification_csv(records, location_name, args.output_dir / f"{location_name}.csv")
         write_scorecard_markdown(all_scorecards, args.output_dir / "scorecard.md")
+        write_scorecard_json(all_scorecards, args.output_dir / "scorecards.json")
         print(f"\nReports written to {args.output_dir}")
+
+    # Compare against previous run if requested
+    if args.compare and all_scorecards:
+        prev_json = args.compare / "scorecards.json"
+        if prev_json.exists():
+            previous = load_scorecard_json(prev_json)
+            print(compare_scorecards(all_scorecards, previous))
+        else:
+            print(f"\nWarning: {prev_json} not found, skipping comparison", file=sys.stderr)

--- a/scripts/backtest/report.py
+++ b/scripts/backtest/report.py
@@ -5,9 +5,10 @@ Writes CSV verification records and markdown scorecards.
 from __future__ import annotations
 
 import csv
+import json
 from pathlib import Path
 
-from scripts.backtest.metrics import ScoreCard, VerificationRecord
+from scripts.backtest.metrics import ContingencyTable, ScoreCard, VerificationRecord
 
 
 _CSV_FIELDS = [
@@ -71,3 +72,85 @@ def write_scorecard_markdown(
 
     lines.append("")
     path.write_text("\n".join(lines))
+
+
+def write_scorecard_json(
+    scorecards: list[ScoreCard],
+    path: Path,
+) -> None:
+    """Write scorecards as JSON for machine-readable comparison."""
+    data = []
+    for sc in scorecards:
+        ct = sc.contingency
+        data.append({
+            "location": sc.location,
+            "total_windows": sc.total_windows,
+            "skipped_gaps": sc.skipped_gaps,
+            "hits": ct.hits,
+            "misses": ct.misses,
+            "false_alarms": ct.false_alarms,
+            "correct_negatives": ct.correct_negatives,
+            "lead_time_errors": sc.lead_time_errors,
+        })
+    path.write_text(json.dumps(data, indent=2))
+
+
+def _format_delta(value: float) -> str:
+    """Format a delta with sign and direction indicator."""
+    sign = "+" if value > 0 else ""
+    return f"{sign}{value:.3f}"
+
+
+def compare_scorecards(
+    current: list[ScoreCard],
+    previous: list[ScoreCard],
+) -> str:
+    """Format a comparison table showing deltas between two runs."""
+    prev_by_loc = {sc.location: sc for sc in previous}
+
+    lines = ["", "## Comparison", ""]
+    lines.append("| Location | POD | FAR | CSI | Bias |")
+    lines.append("|----------|-----|-----|-----|------|")
+
+    for sc in current:
+        prev = prev_by_loc.get(sc.location)
+        if prev is None:
+            lines.append(
+                f"| {sc.location} | {sc.pod:.3f} (new) "
+                f"| {sc.far:.3f} (new) | {sc.csi:.3f} (new) | {sc.bias:.2f} (new) |"
+            )
+        else:
+            pod_d = sc.pod - prev.pod
+            far_d = sc.far - prev.far
+            csi_d = sc.csi - prev.csi
+            bias_d = sc.bias - prev.bias
+            lines.append(
+                f"| {sc.location} "
+                f"| {prev.pod:.3f}→{sc.pod:.3f} ({_format_delta(pod_d)}) "
+                f"| {prev.far:.3f}→{sc.far:.3f} ({_format_delta(far_d)}) "
+                f"| {prev.csi:.3f}→{sc.csi:.3f} ({_format_delta(csi_d)}) "
+                f"| {prev.bias:.2f}→{sc.bias:.2f} ({_format_delta(bias_d)}) |"
+            )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+def load_scorecard_json(path: Path) -> list[ScoreCard]:
+    """Load scorecards from a JSON file."""
+    data = json.loads(path.read_text())
+    scorecards = []
+    for entry in data:
+        scorecards.append(ScoreCard(
+            location=entry["location"],
+            contingency=ContingencyTable(
+                hits=entry["hits"],
+                misses=entry["misses"],
+                false_alarms=entry["false_alarms"],
+                correct_negatives=entry["correct_negatives"],
+            ),
+            total_windows=entry["total_windows"],
+            skipped_gaps=entry["skipped_gaps"],
+            lead_time_errors=entry["lead_time_errors"],
+        ))
+    return scorecards

--- a/tests/unit/backtest/test_cli.py
+++ b/tests/unit/backtest/test_cli.py
@@ -521,3 +521,56 @@ class TestOutputDir:
 
         assert (output_dir / "test_loc.csv").exists(), "CSV file not created"
         assert (output_dir / "scorecard.md").exists(), "Markdown scorecard not created"
+
+
+# ---------------------------------------------------------------------------
+# Test: --compare prints delta table
+# ---------------------------------------------------------------------------
+
+
+class TestCompare:
+    def test_compare_prints_deltas(self, tmp_path: Path, capsys) -> None:
+        """--compare must load previous JSON and print a delta table."""
+        from scripts.backtest.cli import main
+        from scripts.backtest.metrics import ContingencyTable, ScoreCard
+        from scripts.backtest.report import write_scorecard_json
+
+        # Create previous run with JSON scorecard
+        prev_dir = tmp_path / "previous"
+        prev_dir.mkdir()
+        prev_scorecard = ScoreCard(
+            location="test_loc",
+            contingency=ContingencyTable(hits=50, misses=10, false_alarms=20, correct_negatives=100),
+            total_windows=180, skipped_gaps=0, lead_time_errors=[],
+        )
+        write_scorecard_json([prev_scorecard], prev_dir / "scorecards.json")
+
+        # Set up current run
+        data_dir = tmp_path / "data"
+        captures_dir = data_dir / "captures"
+        _make_location_dir(captures_dir, "test_loc")
+        output_dir = tmp_path / "current"
+
+        cur_scorecard = ScoreCard(
+            location="test_loc",
+            contingency=ContingencyTable(hits=60, misses=5, false_alarms=15, correct_negatives=100),
+            total_windows=180, skipped_gaps=0, lead_time_errors=[],
+        )
+
+        with patch("scripts.backtest.cli.ReplayEngine") as MockEngine, \
+             patch("scripts.backtest.cli.FutureRadarVerifier") as MockVerifier, \
+             patch("scripts.backtest.cli.compute_scorecard", return_value=cur_scorecard):
+            instance = MockEngine.return_value
+            instance.replay.return_value = [MagicMock()]
+            verifier_instance = MockVerifier.return_value
+            verifier_instance.verify.return_value = []
+
+            main(["--data-dir", str(data_dir), "--verify",
+                  "--output-dir", str(output_dir),
+                  "--compare", str(prev_dir)])
+
+        captured = capsys.readouterr()
+        assert "Comparison" in captured.out
+        assert "test_loc" in captured.out
+        # JSON scorecard should also be saved
+        assert (output_dir / "scorecards.json").exists()

--- a/tests/unit/backtest/test_report.py
+++ b/tests/unit/backtest/test_report.py
@@ -102,3 +102,68 @@ class TestWriteMarkdownScorecard:
         content = md_path.read_text()
         assert "darwin" in content
         assert "cairns" in content
+
+
+class TestJsonScorecardRoundtrip:
+    def test_write_and_load_produces_same_data(self, tmp_path):
+        """JSON scorecard must roundtrip: write then load produces equivalent scorecards."""
+        from scripts.backtest.report import write_scorecard_json, load_scorecard_json
+
+        original = ScoreCard(
+            location="darwin",
+            contingency=ContingencyTable(hits=99, misses=33, false_alarms=129, correct_negatives=627),
+            total_windows=916,
+            skipped_gaps=28,
+            lead_time_errors=[-7.0, 0.0, 5.0],
+        )
+        json_path = tmp_path / "scorecards.json"
+        write_scorecard_json([original], json_path)
+
+        loaded = load_scorecard_json(json_path)
+        assert len(loaded) == 1
+        assert loaded[0].location == "darwin"
+        assert loaded[0].contingency.hits == 99
+        assert loaded[0].contingency.misses == 33
+        assert loaded[0].contingency.false_alarms == 129
+        assert loaded[0].contingency.correct_negatives == 627
+        assert loaded[0].total_windows == 916
+        assert loaded[0].skipped_gaps == 28
+        assert loaded[0].lead_time_errors == [-7.0, 0.0, 5.0]
+
+
+class TestCompareScorecards:
+    def test_compare_shows_deltas(self):
+        """Compare must show before→after values and deltas for each metric."""
+        from scripts.backtest.report import compare_scorecards
+
+        previous = [ScoreCard(
+            location="darwin",
+            contingency=ContingencyTable(hits=99, misses=33, false_alarms=129, correct_negatives=627),
+            total_windows=916, skipped_gaps=28, lead_time_errors=[],
+        )]
+        current = [ScoreCard(
+            location="darwin",
+            contingency=ContingencyTable(hits=120, misses=12, false_alarms=80, correct_negatives=676),
+            total_windows=916, skipped_gaps=28, lead_time_errors=[],
+        )]
+
+        output = compare_scorecards(current, previous)
+
+        assert "darwin" in output
+        assert "POD" in output
+        assert "FAR" in output
+        assert "CSI" in output
+
+    def test_compare_missing_location_shows_new(self):
+        """A location in current but not previous should show as new."""
+        from scripts.backtest.report import compare_scorecards
+
+        previous = []
+        current = [ScoreCard(
+            location="new_loc",
+            contingency=ContingencyTable(hits=10),
+            total_windows=20, skipped_gaps=0, lead_time_errors=[],
+        )]
+
+        output = compare_scorecards(current, previous)
+        assert "new_loc" in output


### PR DESCRIPTION
## Summary

Phase 2A of the curated test suite plan. Enables comparing backtest runs.

- `write_scorecard_json` / `load_scorecard_json` - machine-readable scorecard persistence
- `compare_scorecards` - delta table showing before→after for POD/FAR/CSI/Bias
- `--compare <previous-dir>` - loads previous scorecards.json, prints deltas
- `--output-dir` now auto-saves `scorecards.json` alongside markdown

```bash
python -m scripts.backtest --data-dir backtest_data --locations all \
  --qc full --verify --output-dir reports/qc-full \
  --compare reports/baseline
```

4 new tests (TDD). 604 total.

## Test plan
- [x] 604 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)