### PR TITLE
Add curated test suite: selector, manifest, and subset replay (Phase 2B+2C)

### DIFF
--- a/scripts/backtest/cli.py
+++ b/scripts/backtest/cli.py
@@ -82,8 +82,32 @@ def main(argv: list[str] | None = None) -> None:
     parser.add_argument(
         "--data-dir",
         type=Path,
-        required=True,
+        default=None,
         help="Root directory containing captures/ and observations/",
+    )
+    parser.add_argument(
+        "--generate-subset",
+        type=Path,
+        default=None,
+        help="Generate a manifest from a previous run's CSV directory, then exit",
+    )
+    parser.add_argument(
+        "--n-per-category",
+        type=int,
+        default=20,
+        help="With --generate-subset, number of windows per category per location",
+    )
+    parser.add_argument(
+        "--manifest-output",
+        type=Path,
+        default=None,
+        help="With --generate-subset, path to write the manifest JSON",
+    )
+    parser.add_argument(
+        "--subset",
+        type=Path,
+        default=None,
+        help="Replay only windows listed in this manifest JSON",
     )
     parser.add_argument(
         "--locations",
@@ -127,6 +151,22 @@ def main(argv: list[str] | None = None) -> None:
 
     args = parser.parse_args(argv)
 
+    # Handle --generate-subset mode (doesn't need --data-dir)
+    if args.generate_subset:
+        from scripts.backtest.selector import select_representative_windows
+        from scripts.backtest.manifest import save_manifest
+
+        entries = select_representative_windows(args.generate_subset, args.n_per_category)
+        output_path = args.manifest_output or Path("manifest.json")
+        save_manifest(entries, "quick", "Auto-generated curated subset",
+                      str(args.generate_subset), output_path)
+        print(f"Generated manifest with {len(entries)} windows at {output_path}")
+        return
+
+    if args.data_dir is None:
+        print("Error: --data-dir is required for replay mode", file=sys.stderr)
+        sys.exit(1)
+
     captures_dir = args.data_dir / "captures"
     if not captures_dir.is_dir():
         print(f"Error: {captures_dir} not found", file=sys.stderr)
@@ -152,6 +192,16 @@ def main(argv: list[str] | None = None) -> None:
     all_scorecards: list[ScoreCard] = []
     all_records: dict[str, list[VerificationRecord]] = {}
 
+    # Load manifest if --subset specified
+    manifest_by_location: dict[str, list] | None = None
+    if args.subset:
+        from scripts.backtest.manifest import load_manifest
+        manifest = load_manifest(args.subset)
+        manifest_by_location = {}
+        for entry in manifest.entries:
+            manifest_by_location.setdefault(entry.location, []).append(entry)
+        print(f"Using manifest: {manifest.name} ({len(manifest.entries)} windows)")
+
     for loc_dir in location_dirs:
         location_name = loc_dir.name
         captures = load_captures(loc_dir)
@@ -159,7 +209,13 @@ def main(argv: list[str] | None = None) -> None:
             print(f"{location_name}: no captures found, skipping")
             continue
 
-        predictions = engine.replay(captures)
+        if manifest_by_location is not None:
+            loc_entries = manifest_by_location.get(location_name, [])
+            if not loc_entries:
+                continue  # no manifest entries for this location
+            predictions = engine.replay_manifest(captures, loc_entries)
+        else:
+            predictions = engine.replay(captures)
 
         if args.verify:
             total_possible_windows = max(0, len(captures) - config.window_size + 1)

--- a/scripts/backtest/manifest.py
+++ b/scripts/backtest/manifest.py
@@ -1,0 +1,80 @@
+"""Manifest: a curated list of windows for quick backtesting.
+
+A manifest selects specific windows from a full baseline run that
+represent the important categories (hits, misses, false alarms,
+correct negatives) for fast algorithm iteration.
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ManifestEntry:
+    """One selected window in the manifest."""
+
+    location: str
+    window_end_ts: int
+    category: str       # hit, miss, false_alarm, correct_negative
+    subcategory: str    # strong, marginal, overhead_noise, dissipated, etc.
+
+
+@dataclass
+class Manifest:
+    """A curated set of windows for quick backtesting."""
+
+    name: str
+    description: str
+    created_from: str
+    created_at: str
+    entries: list[ManifestEntry]
+
+
+def save_manifest(
+    entries: list[ManifestEntry],
+    name: str,
+    description: str,
+    source_dir: str,
+    path: Path,
+) -> None:
+    """Save a manifest to a JSON file."""
+    data = {
+        "name": name,
+        "description": description,
+        "created_from": source_dir,
+        "created_at": datetime.now(timezone.utc).isoformat(),
+        "windows": [
+            {
+                "location": e.location,
+                "window_end_ts": e.window_end_ts,
+                "category": e.category,
+                "subcategory": e.subcategory,
+            }
+            for e in entries
+        ],
+    }
+    path.write_text(json.dumps(data, indent=2))
+
+
+def load_manifest(path: Path) -> Manifest:
+    """Load a manifest from a JSON file."""
+    data = json.loads(path.read_text())
+    entries = [
+        ManifestEntry(
+            location=w["location"],
+            window_end_ts=w["window_end_ts"],
+            category=w["category"],
+            subcategory=w["subcategory"],
+        )
+        for w in data["windows"]
+    ]
+    return Manifest(
+        name=data["name"],
+        description=data["description"],
+        created_from=data["created_from"],
+        created_at=data["created_at"],
+        entries=entries,
+    )

--- a/scripts/backtest/replay.py
+++ b/scripts/backtest/replay.py
@@ -280,3 +280,63 @@ class ReplayEngine:
             predictions.append(_to_prediction(result, frames, window))
 
         return predictions
+
+    def replay_manifest(
+        self,
+        captures: list[CaptureRecord],
+        manifest_entries: list,
+    ) -> list[PredictionRecord]:
+        """Replay only specific windows listed in a manifest.
+
+        For each manifest entry, finds the window of captures ending at
+        the entry's window_end_ts and runs detect() on it.
+        """
+        from scripts.backtest.manifest import ManifestEntry
+
+        config = self._config
+        window_size = config.window_size
+
+        sorted_captures = sorted(captures, key=lambda r: r.frame_ts)
+
+        # Build frame cache and index captures by ts for fast lookup
+        frame_cache: dict[int, CapturedRadarFrame] = {
+            r.frame_ts: _frame_from_record(r) for r in sorted_captures
+        }
+        ts_list = [r.frame_ts for r in sorted_captures]
+        ts_to_idx = {ts: i for i, ts in enumerate(ts_list)}
+
+        # Collect target timestamps from manifest
+        target_ts = {e.window_end_ts for e in manifest_entries}
+
+        predictions: list[PredictionRecord] = []
+
+        for end_ts in sorted(target_ts):
+            end_idx = ts_to_idx.get(end_ts)
+            if end_idx is None or end_idx < window_size - 1:
+                continue  # can't build a full window
+
+            start_idx = end_idx - window_size + 1
+            window = sorted_captures[start_idx : end_idx + 1]
+
+            if _has_gap(window, config.max_gap_seconds):
+                continue
+
+            frames = [frame_cache[r.frame_ts] for r in window]
+            detector_config = _build_detector_config(window[0], config.lookahead_seconds)
+
+            confidence_maps: list[np.ndarray] | None = None
+            if config.qc_enabled:
+                confidence_maps = _compute_confidence_maps(
+                    frames, detector_config, None, 0.0
+                )
+
+            result = detect(
+                frames=frames,
+                location=(window[0].lat, window[0].lon),
+                config=detector_config,
+                confidence_maps=confidence_maps,
+            )
+
+            predictions.append(_to_prediction(result, frames, window))
+
+        return predictions

--- a/scripts/backtest/selector.py
+++ b/scripts/backtest/selector.py
@@ -1,0 +1,107 @@
+"""Select representative windows from a baseline run for quick backtesting.
+
+Reads per-location CSVs and picks N windows per category, spread across
+the score distribution so the curated set covers the important scenarios.
+"""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+from scripts.backtest.manifest import ManifestEntry
+
+
+def _classify_subcategory(row: dict) -> str:
+    """Assign a subcategory based on arrival times."""
+    predicted = row.get("predicted_arrival_minutes", "")
+    actual = row.get("actual_arrival_minutes", "")
+    category = _classify_category(row)
+
+    if category == "hit":
+        # Strong vs marginal based on lead time error
+        if predicted and actual:
+            error = abs(float(predicted) - float(actual))
+            return "strong" if error <= 10 else "marginal"
+        return "strong"
+
+    if category == "false_alarm":
+        if predicted:
+            mins = float(predicted)
+            if mins <= 0:
+                return "overhead_noise"
+            if mins <= 25:
+                return "near_miss"
+            return "dissipated"
+        return "overhead_noise"
+
+    if category == "miss":
+        if actual:
+            mins = float(actual)
+            return "approaching_undetected" if mins <= 30 else "popup"
+        return "popup"
+
+    # correct_negative
+    return "dead_dry"
+
+
+def _classify_category(row: dict) -> str:
+    """Classify a CSV row into hit/miss/false_alarm/correct_negative."""
+    predicted = row["predicted_rain"] == "True"
+    actual = row["actual_rain"] == "True"
+    if predicted and actual:
+        return "hit"
+    if not predicted and actual:
+        return "miss"
+    if predicted and not actual:
+        return "false_alarm"
+    return "correct_negative"
+
+
+def _spread_select(items: list, n: int) -> list:
+    """Select N items evenly spread across the list.
+
+    Takes items at regular intervals including first and last,
+    giving a representative sample of the distribution.
+    """
+    if len(items) <= n:
+        return list(items)
+    if n <= 0:
+        return []
+    if n == 1:
+        return [items[len(items) // 2]]
+    step = (len(items) - 1) / (n - 1)
+    return [items[int(round(i * step))] for i in range(n)]
+
+
+def select_representative_windows(
+    csv_dir: Path,
+    n_per_category: int = 20,
+) -> list[ManifestEntry]:
+    """Select representative windows from baseline CSVs.
+
+    For each location CSV, groups rows by category and selects N
+    windows spread across the distribution.
+    """
+    entries: list[ManifestEntry] = []
+
+    for csv_path in sorted(csv_dir.glob("*.csv")):
+        # Group rows by category
+        by_category: dict[str, list[dict]] = {}
+        with open(csv_path, newline="") as f:
+            for row in csv.DictReader(f):
+                cat = _classify_category(row)
+                by_category.setdefault(cat, []).append(row)
+
+        location = csv_path.stem
+
+        for category, rows in by_category.items():
+            selected = _spread_select(rows, n_per_category)
+            for row in selected:
+                entries.append(ManifestEntry(
+                    location=location,
+                    window_end_ts=int(row["window_end_ts"]),
+                    category=category,
+                    subcategory=_classify_subcategory(row),
+                ))
+
+    return entries

--- a/tests/unit/backtest/test_cli.py
+++ b/tests/unit/backtest/test_cli.py
@@ -67,12 +67,12 @@ def _make_prediction(
 
 class TestMainWithNoArgs:
     def test_main_with_no_args_exits_with_error(self) -> None:
-        """Calling main() with no arguments triggers argparse SystemExit(2)."""
+        """Calling main() with no --data-dir and no --generate-subset exits with code 1."""
         from scripts.backtest.cli import main
 
         with pytest.raises(SystemExit) as exc_info:
             main([])
-        assert exc_info.value.code == 2
+        assert exc_info.value.code == 1
 
 
 # ---------------------------------------------------------------------------
@@ -574,3 +574,39 @@ class TestCompare:
         assert "test_loc" in captured.out
         # JSON scorecard should also be saved
         assert (output_dir / "scorecards.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# Test: --generate-subset creates a manifest from CSVs
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSubset:
+    def test_generate_subset_creates_manifest(self, tmp_path: Path, capsys) -> None:
+        """--generate-subset must read CSVs and write a manifest JSON."""
+        from scripts.backtest.cli import main
+
+        # Create a minimal CSV
+        csv_dir = tmp_path / "baseline"
+        csv_dir.mkdir()
+        csv_path = csv_dir / "test_loc.csv"
+        csv_path.write_text(
+            "location,window_end_ts,predicted_rain,actual_rain,predicted_arrival_minutes,actual_arrival_minutes\n"
+            "test_loc,1000,True,True,30,25\n"
+            "test_loc,2000,False,True,,10\n"
+            "test_loc,3000,True,False,45,\n"
+            "test_loc,4000,False,False,,\n"
+        )
+
+        manifest_path = tmp_path / "quick.json"
+
+        main(["--generate-subset", str(csv_dir),
+              "--n-per-category", "2",
+              "--manifest-output", str(manifest_path)])
+
+        assert manifest_path.exists(), "Manifest file not created"
+
+        import json
+        data = json.loads(manifest_path.read_text())
+        assert "windows" in data
+        assert len(data["windows"]) > 0

--- a/tests/unit/backtest/test_manifest.py
+++ b/tests/unit/backtest/test_manifest.py
@@ -1,0 +1,41 @@
+"""Unit tests for scripts.backtest.manifest - manifest save/load/filter."""
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+
+class TestManifestRoundtrip:
+    def test_save_and_load_preserves_entries(self, tmp_path):
+        """Manifest must roundtrip: save then load produces identical entries."""
+        from scripts.backtest.manifest import ManifestEntry, save_manifest, load_manifest
+
+        entries = [
+            ManifestEntry(
+                location="darwin",
+                window_end_ts=1776345600,
+                category="false_alarm",
+                subcategory="overhead_noise",
+            ),
+            ManifestEntry(
+                location="darwin",
+                window_end_ts=1776346200,
+                category="hit",
+                subcategory="strong",
+            ),
+        ]
+        path = tmp_path / "test.json"
+        save_manifest(entries, "test-v1", "Test manifest", "reports/baseline", path)
+
+        loaded = load_manifest(path)
+        assert loaded.name == "test-v1"
+        assert loaded.description == "Test manifest"
+        assert loaded.created_from == "reports/baseline"
+        assert len(loaded.entries) == 2
+        assert loaded.entries[0].location == "darwin"
+        assert loaded.entries[0].window_end_ts == 1776345600
+        assert loaded.entries[0].category == "false_alarm"
+        assert loaded.entries[0].subcategory == "overhead_noise"

--- a/tests/unit/backtest/test_replay.py
+++ b/tests/unit/backtest/test_replay.py
@@ -427,3 +427,38 @@ class TestFrameCachingAcrossWindows:
             f"{len(captures)} captures - frames are being rebuilt per window "
             f"instead of cached"
         )
+
+
+# ---------------------------------------------------------------------------
+# Replay from manifest: only replay specific windows, not all consecutive
+# ---------------------------------------------------------------------------
+
+
+class TestReplayManifest:
+    """replay_manifest must replay only the windows listed in the manifest."""
+
+    def test_replays_only_manifest_windows(self):
+        """Only windows whose window_end_ts matches a manifest entry should be replayed."""
+        from scripts.backtest.manifest import ManifestEntry
+
+        captures = _make_records(10)  # ts: BASE+0 through BASE+5400
+        # Pick only 2 specific windows (window_end_ts = ts of last frame in window)
+        manifest_entries = [
+            ManifestEntry(location="Melbourne_dry", window_end_ts=_BASE_TS + 7 * 600,
+                          category="hit", subcategory="strong"),
+            ManifestEntry(location="Melbourne_dry", window_end_ts=_BASE_TS + 9 * 600,
+                          category="false_alarm", subcategory="overhead_noise"),
+        ]
+
+        engine = ReplayEngine(ReplayConfig(window_size=8, qc_enabled=False))
+
+        with patch("scripts.backtest.replay.detect", return_value=_mock_detect_result()):
+            predictions = engine.replay_manifest(captures, manifest_entries)
+
+        assert len(predictions) == 2, (
+            f"Expected 2 predictions for 2 manifest entries, got {len(predictions)}"
+        )
+        # Verify the correct window_end_ts values
+        pred_ts = {p.window_end_ts for p in predictions}
+        assert _BASE_TS + 7 * 600 in pred_ts
+        assert _BASE_TS + 9 * 600 in pred_ts

--- a/tests/unit/backtest/test_selector.py
+++ b/tests/unit/backtest/test_selector.py
@@ -1,0 +1,103 @@
+"""Unit tests for scripts.backtest.selector - representative window selection."""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+import pytest
+
+
+def _write_csv(path: Path, rows: list[dict]) -> None:
+    """Write a CSV file from a list of dicts."""
+    fields = ["location", "window_end_ts", "predicted_rain", "actual_rain",
+              "predicted_arrival_minutes", "actual_arrival_minutes"]
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=fields)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+def _make_rows(location: str, n_hits: int, n_misses: int, n_fa: int, n_cn: int) -> list[dict]:
+    """Build synthetic CSV rows with known category distribution."""
+    rows = []
+    ts = 1776200000
+    for i in range(n_hits):
+        rows.append({"location": location, "window_end_ts": ts, "predicted_rain": "True",
+                      "actual_rain": "True", "predicted_arrival_minutes": str(i * 5),
+                      "actual_arrival_minutes": str(i * 5 + 2)})
+        ts += 600
+    for i in range(n_misses):
+        rows.append({"location": location, "window_end_ts": ts, "predicted_rain": "False",
+                      "actual_rain": "True", "predicted_arrival_minutes": "",
+                      "actual_arrival_minutes": str(i * 10)})
+        ts += 600
+    for i in range(n_fa):
+        rows.append({"location": location, "window_end_ts": ts, "predicted_rain": "True",
+                      "actual_rain": "False", "predicted_arrival_minutes": str(i * 3),
+                      "actual_arrival_minutes": ""})
+        ts += 600
+    for i in range(n_cn):
+        rows.append({"location": location, "window_end_ts": ts, "predicted_rain": "False",
+                      "actual_rain": "False", "predicted_arrival_minutes": "",
+                      "actual_arrival_minutes": ""})
+        ts += 600
+    return rows
+
+
+class TestSelectRepresentativeWindows:
+    def test_selects_from_all_categories(self, tmp_path):
+        """Selector must pick windows from hits, misses, FA, and CN."""
+        from scripts.backtest.selector import select_representative_windows
+
+        _write_csv(tmp_path / "darwin.csv", _make_rows("darwin", 50, 20, 30, 100))
+
+        entries = select_representative_windows(tmp_path, n_per_category=5)
+
+        categories = {e.category for e in entries}
+        assert "hit" in categories
+        assert "miss" in categories
+        assert "false_alarm" in categories
+        assert "correct_negative" in categories
+
+    def test_respects_n_per_category(self, tmp_path):
+        """Must select at most n_per_category per category per location."""
+        from scripts.backtest.selector import select_representative_windows
+
+        _write_csv(tmp_path / "darwin.csv", _make_rows("darwin", 50, 20, 30, 100))
+
+        entries = select_representative_windows(tmp_path, n_per_category=5)
+        darwin_entries = [e for e in entries if e.location == "darwin"]
+
+        for cat in ["hit", "miss", "false_alarm", "correct_negative"]:
+            count = sum(1 for e in darwin_entries if e.category == cat)
+            assert count <= 5, f"Expected at most 5 {cat}, got {count}"
+
+    def test_takes_all_when_fewer_than_n(self, tmp_path):
+        """When a category has fewer than N windows, take all of them."""
+        from scripts.backtest.selector import select_representative_windows
+
+        _write_csv(tmp_path / "darwin.csv", _make_rows("darwin", 3, 2, 1, 100))
+
+        entries = select_representative_windows(tmp_path, n_per_category=20)
+        darwin_entries = [e for e in entries if e.location == "darwin"]
+
+        hits = [e for e in darwin_entries if e.category == "hit"]
+        misses = [e for e in darwin_entries if e.category == "miss"]
+        fa = [e for e in darwin_entries if e.category == "false_alarm"]
+        assert len(hits) == 3
+        assert len(misses) == 2
+        assert len(fa) == 1
+
+    def test_multiple_locations(self, tmp_path):
+        """Selector must process all CSV files in the directory."""
+        from scripts.backtest.selector import select_representative_windows
+
+        _write_csv(tmp_path / "darwin.csv", _make_rows("darwin", 10, 5, 5, 20))
+        _write_csv(tmp_path / "cairns.csv", _make_rows("cairns", 10, 5, 5, 20))
+
+        entries = select_representative_windows(tmp_path, n_per_category=3)
+
+        locations = {e.location for e in entries}
+        assert "darwin" in locations
+        assert "cairns" in locations


### PR DESCRIPTION
## Summary

The full backtest takes ~60 minutes. This PR enables quick iteration by selecting representative windows from a baseline run and replaying only those.

### New components

- **manifest.py**: ManifestEntry dataclass + JSON save/load
- **selector.py**: Reads baseline CSVs, picks N windows per category per location (hits, misses, false alarms, correct negatives) with subcategories (overhead_noise, dissipated, approaching_undetected, etc.)
- **replay_manifest()**: Replays only specific windows from a manifest

### Usage

```bash
# 1. Generate curated subset from baseline (instant)
python -m scripts.backtest --generate-subset reports/baseline \
  --n-per-category 20 --manifest-output manifests/quick.json

# 2. Quick iteration (~seconds instead of ~60min)
python -m scripts.backtest --data-dir backtest_data --locations all \
  --qc full --verify --subset manifests/quick.json \
  --output-dir reports/quick-qc-full --compare reports/baseline
```

### New CLI flags
- `--generate-subset <csv-dir>` + `--n-per-category N` + `--manifest-output <path>`
- `--subset <manifest.json>`

7 new tests (TDD). 611 total.

## Test plan
- [x] 611 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)