### PR TITLE
Fix manifest replay: only load needed captures, fix window count

### DIFF
--- a/scripts/backtest/cli.py
+++ b/scripts/backtest/cli.py
@@ -218,9 +218,21 @@ def main(argv: list[str] | None = None) -> None:
             predictions = engine.replay(captures)
 
         if args.verify:
-            total_possible_windows = max(0, len(captures) - config.window_size + 1)
+            if manifest_by_location is not None:
+                total_possible_windows = len(manifest_by_location.get(location_name, []))
+            else:
+                total_possible_windows = max(0, len(captures) - config.window_size + 1)
             skipped_gaps = total_possible_windows - len(predictions)
-            verifier = FutureRadarVerifier(captures)
+            # In manifest mode, only pass captures needed for verification
+            # (the windows themselves + lookahead period) to avoid loading
+            # all 1000+ captures into the verifier's frame cache
+            if manifest_by_location is not None and predictions:
+                min_ts = min(p.window_end_ts for p in predictions)
+                max_ts = max(p.window_end_ts for p in predictions) + config.lookahead_seconds
+                verify_captures = [c for c in captures if min_ts <= c.frame_ts <= max_ts]
+            else:
+                verify_captures = captures
+            verifier = FutureRadarVerifier(verify_captures)
             records = verifier.verify(predictions)
             scorecard = compute_scorecard(
                 location_name, records, total_possible_windows, skipped_gaps

--- a/scripts/backtest/replay.py
+++ b/scripts/backtest/replay.py
@@ -298,15 +298,24 @@ class ReplayEngine:
 
         sorted_captures = sorted(captures, key=lambda r: r.frame_ts)
 
-        # Build frame cache and index captures by ts for fast lookup
-        frame_cache: dict[int, CapturedRadarFrame] = {
-            r.frame_ts: _frame_from_record(r) for r in sorted_captures
-        }
         ts_list = [r.frame_ts for r in sorted_captures]
         ts_to_idx = {ts: i for i, ts in enumerate(ts_list)}
 
         # Collect target timestamps from manifest
         target_ts = {e.window_end_ts for e in manifest_entries}
+
+        # Only build frames for captures that are part of a manifest window
+        needed_indices: set[int] = set()
+        for end_ts in target_ts:
+            end_idx = ts_to_idx.get(end_ts)
+            if end_idx is not None and end_idx >= window_size - 1:
+                for i in range(end_idx - window_size + 1, end_idx + 1):
+                    needed_indices.add(i)
+
+        frame_cache: dict[int, CapturedRadarFrame] = {
+            sorted_captures[i].frame_ts: _frame_from_record(sorted_captures[i])
+            for i in needed_indices
+        }
 
         predictions: list[PredictionRecord] = []
 

--- a/tests/unit/backtest/test_cli.py
+++ b/tests/unit/backtest/test_cli.py
@@ -610,3 +610,60 @@ class TestGenerateSubset:
         data = json.loads(manifest_path.read_text())
         assert "windows" in data
         assert len(data["windows"]) > 0
+
+
+# ---------------------------------------------------------------------------
+# Test: --subset reports manifest window count, not total captures
+# ---------------------------------------------------------------------------
+
+
+class TestSubsetWindowCount:
+    def test_subset_reports_manifest_count_not_total(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """With --subset, the scorecard must show manifest windows, not total captures."""
+        from scripts.backtest.cli import main
+        from scripts.backtest.metrics import ContingencyTable, ScoreCard
+        from scripts.backtest.manifest import ManifestEntry, save_manifest
+
+        data_dir = tmp_path / "data"
+        captures_dir = data_dir / "captures"
+        _make_location_dir(captures_dir, "test_loc")
+
+        # Create a manifest with 3 windows
+        manifest_path = tmp_path / "manifest.json"
+        entries = [
+            ManifestEntry(location="test_loc", window_end_ts=1000+i*600,
+                          category="hit", subcategory="strong")
+            for i in range(3)
+        ]
+        save_manifest(entries, "test", "test", "test", manifest_path)
+
+        scorecard = ScoreCard(
+            location="test_loc",
+            contingency=ContingencyTable(hits=3),
+            total_windows=3,
+            skipped_gaps=0,
+            lead_time_errors=[],
+        )
+
+        with patch("scripts.backtest.cli.ReplayEngine") as MockEngine, \
+             patch("scripts.backtest.cli.FutureRadarVerifier") as MockVerifier, \
+             patch("scripts.backtest.cli.compute_scorecard", return_value=scorecard) as mock_sc:
+            instance = MockEngine.return_value
+            instance.replay_manifest.return_value = [
+                _make_prediction(window_end_ts=1000+i*600) for i in range(3)
+            ]
+            verifier_instance = MockVerifier.return_value
+            verifier_instance.verify.return_value = []
+
+            main(["--data-dir", str(data_dir), "--verify",
+                  "--subset", str(manifest_path)])
+
+        # compute_scorecard should be called with total_windows=3 (manifest count)
+        # not the number of captures
+        call_args = mock_sc.call_args
+        assert call_args[1].get("total_windows", call_args[0][2] if len(call_args[0]) > 2 else None) == 3 or \
+               (len(call_args[0]) > 2 and call_args[0][2] == 3), (
+            f"total_windows should be 3 (manifest count), got {call_args}"
+        )

--- a/tests/unit/backtest/test_replay.py
+++ b/tests/unit/backtest/test_replay.py
@@ -462,3 +462,37 @@ class TestReplayManifest:
         pred_ts = {p.window_end_ts for p in predictions}
         assert _BASE_TS + 7 * 600 in pred_ts
         assert _BASE_TS + 9 * 600 in pred_ts
+
+
+class TestReplayManifestOnlyLoadNeededCaptures:
+    """replay_manifest must only build frames for captures that are part of
+    a manifest window, not all captures in the dataset."""
+
+    def test_frame_from_record_called_only_for_needed_captures(self):
+        """With 100 captures but a manifest selecting 2 windows (needing ~16 captures),
+        _frame_from_record should be called ~16 times, not 100."""
+        from scripts.backtest.manifest import ManifestEntry
+
+        captures = _make_records(100)
+        # Select 2 windows: one at index 7 (needs captures 0-7) and one at index 15 (needs 8-15)
+        manifest_entries = [
+            ManifestEntry(location="Melbourne_dry", window_end_ts=_BASE_TS + 7 * 600,
+                          category="hit", subcategory="strong"),
+            ManifestEntry(location="Melbourne_dry", window_end_ts=_BASE_TS + 15 * 600,
+                          category="miss", subcategory="popup"),
+        ]
+
+        engine = ReplayEngine(ReplayConfig(window_size=8, qc_enabled=False))
+
+        with patch("scripts.backtest.replay.detect", return_value=_mock_detect_result()):
+            with patch(
+                "scripts.backtest.replay._frame_from_record",
+                wraps=__import__("scripts.backtest.replay", fromlist=["_frame_from_record"])._frame_from_record,
+            ) as mock_frame:
+                engine.replay_manifest(captures, manifest_entries)
+
+        # 2 windows × 8 frames = 16 unique captures needed (no overlap in this case)
+        assert mock_frame.call_count <= 16, (
+            f"_frame_from_record called {mock_frame.call_count} times for "
+            f"2 manifest windows - should only build frames for needed captures, not all {len(captures)}"
+        )


### PR DESCRIPTION
## Summary

Three bugs in manifest replay mode:

1. `replay_manifest` built frame cache for ALL captures (1299 per location) even when the manifest only needed ~16. Now computes needed indices and only builds those frames.
2. CLI reported `total_possible_windows` from `len(captures)` instead of `len(manifest_entries)` when using `--subset`.
3. Verifier received all captures in manifest mode. Now filters to only the verification time range.

These combined to make the "quick iteration" flow take ~10 minutes instead of seconds.

2 new tests (TDD). 613 total.

## Test plan
- [x] 613 tests pass locally
- [ ] CI passes
- [ ] Quick subset run completes in seconds, not minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)