### PR TITLE
V1: Align verifier proximity with detector (km-based)

### DIFF
--- a/docs/backtest-investigations.md
+++ b/docs/backtest-investigations.md
@@ -4,23 +4,27 @@ Baseline run: 2026-04-24, 10 days of data, 8 locations, `--qc none`.
 
 ## Baseline Results
 
+Corrected baseline (V1: verifier aligned to 15km, matching detector proximity).
+Previous baseline used a ~5km verifier radius that inflated FAR and deflated miss counts.
+
 | Location | POD | FAR | CSI | Bias | Hits | Misses | FA | CN |
 |----------|-----|-----|-----|------|------|--------|----|----|
-| cairns_babinda | 0.972 | 0.052 | 0.923 | 1.02 | 827 | 24 | 45 | 361 |
-| lake_margaret | 0.916 | 0.130 | 0.806 | 1.05 | 241 | 22 | 36 | 958 |
-| quillayute | 0.939 | 0.388 | 0.588 | 1.53 | 413 | 27 | 262 | 555 |
-| hilo | 0.860 | 0.263 | 0.658 | 1.17 | 154 | 25 | 55 | 1023 |
-| mobile | 0.820 | 0.380 | 0.546 | 1.32 | 201 | 44 | 123 | 889 |
-| darwin | 0.810 | 0.571 | 0.390 | 1.89 | 149 | 35 | 198 | 875 |
-| penrith | 0.649 | 0.523 | 0.379 | 1.36 | 135 | 73 | 148 | 901 |
+| cairns_babinda | 0.956 | 0.025 | 0.933 | 0.98 | 850 | 39 | 22 | 346 |
+| lake_margaret | 0.895 | 0.076 | 0.834 | 0.97 | 256 | 30 | 21 | 950 |
+| quillayute | 0.830 | 0.135 | 0.735 | 0.96 | 584 | 120 | 91 | 462 |
+| hilo | 0.785 | 0.110 | 0.715 | 0.88 | 186 | 51 | 23 | 997 |
+| darwin | 0.772 | 0.297 | 0.582 | 1.10 | 244 | 72 | 103 | 838 |
+| mobile | 0.641 | 0.164 | 0.569 | 0.77 | 271 | 152 | 53 | 781 |
+| penrith | 0.502 | 0.265 | 0.425 | 0.68 | 208 | 206 | 75 | 768 |
 | ketchikan | - | - | 1.000 | 0.00 | 0 | 0 | 0 | 1257 |
 
 ## Key Findings
 
-- Detection is good (POD 0.65-0.97) but false alarms are the main problem (FAR 0.05-0.57)
-- Over-prediction everywhere (Bias > 1.0 at all rain locations)
-- Tropical/maritime locations (Cairns, Hilo) outperform terrain-affected locations (Penrith, Darwin)
-- Lead time errors consistently negative (late predictions, mean -4.6 to -12.0min)
+- Tropical/maritime locations (Cairns CSI 0.933, Lake Margaret 0.834) strongly outperform terrain-affected locations (Penrith 0.425, Mobile 0.569)
+- Penrith and Mobile are under-detecting (bias 0.68 and 0.77) - missing ~50% and ~36% of rain events
+- Darwin is the only remaining over-predictor (bias 1.10, FAR 0.297)
+- Lead time errors consistently negative (late predictions, mean -0.6 to -5.6min)
+- Penrith has the worst lead time accuracy (mean -5.6min) - terrain slows/kills approaching cells
 
 ## Investigation Queue
 
@@ -101,8 +105,57 @@ Each item is a hypothesis to test via quick subset run then validate with full r
 
 ### Verification alignment
 
-- **V1: Align detection and verification proximity** - detector uses 128km, verifier uses ~30km. Many "false alarms" may be correct detections of rain that passes nearby but not overhead. Test with verifier proximity matching detector proximity.
+- **V1: Align detection and verification proximity** - DONE. See V1 results below.
 - **V2: Extended verification window** - currently 60min. Some "false alarms" may be rain that arrived after 60min. Test 90min and 120min windows to reclassify.
+
+## V1 Results: Verifier Proximity Alignment
+
+**Problem**: The verifier used a fixed 10-pixel neighborhood (`proximity_pixels=10`, half=5) regardless of location. This translated to only ~5km radius at mid-latitudes and ~3.4km at high latitudes. Meanwhile the detector uses `PROXIMITY_RADIUS_KM=15.0` converted to pixels dynamically (~14px at mid-latitudes). Rain arriving within 15km (which the detector correctly flagged) was being classified as "no rain arrived" by the narrow verifier, creating phantom false alarms.
+
+The original V1 hypothesis incorrectly stated "128km vs 30km" - 128km is a radar display radius, and 30km overstated the verifier's actual reach. The real mismatch was 15km (detector) vs 3-6km (verifier), a 2.5-4.4x ratio depending on latitude.
+
+**Fix**: Replaced `VerifierConfig.proximity_pixels` with `proximity_km` (default `PROXIMITY_RADIUS_KM=15.0`). The verifier now computes pixel radius from km using the same formula as the detector, so detection and verification are geometrically consistent.
+
+**Mismatch by location** (old 10px half=5 vs new 15km):
+
+| Location | Latitude | Old radius (km) | New radius (km) | Ratio |
+|----------|----------|-----------------|-----------------|-------|
+| Ketchikan | 55.4 | 3.4 | 15.0 | 4.4x |
+| Quillayute | 47.9 | 4.2 | 15.0 | 3.6x |
+| Penrith | -33.8 | 5.0 | 15.0 | 3.0x |
+| Hilo | 19.7 | 5.8 | 15.0 | 2.6x |
+| Cairns | -17.4 | 5.8 | 15.0 | 2.6x |
+| Darwin | -12.5 | 6.0 | 15.0 | 2.5x |
+
+**Quick subset reclassification** (10 curated FAs per location):
+
+| Location | Phantom FAs | Old CNs now Misses | Net |
+|----------|-------------|--------------------|----|
+| Cairns | 8/10 (80%) | 1/10 | Strong - nearly all FAs were real rain just outside old radius |
+| Penrith | 7/10 (70%) | 0/10 | Strong - 70% of Penrith FAs were phantom |
+| Hilo | 7/10 (70%) | 0/10 | Strong |
+| Darwin | 6/10 (60%) | 0/10 | Good |
+| Mobile | 6/10 (60%) | 0/10 | Good |
+| Quillayute | 4/10 (40%) | 4/10 | Mixed - wider radius also catches more real rain events at high latitude |
+| Lake Margaret | 3/10 (30%) | 0/10 | Modest |
+
+**Full population results** (qc=none, 10 days, all windows):
+
+| Location | POD | FAR | CSI | Bias | FA→Hit | CN→Miss |
+|----------|-----|-----|-----|------|--------|---------|
+| cairns_babinda | 0.956 | 0.025 | 0.933 | 0.98 | +23 | +15 |
+| quillayute | 0.830 | 0.135 | 0.735 | 0.96 | +171 | +93 |
+| lake_margaret | 0.895 | 0.076 | 0.834 | 0.97 | +15 | +8 |
+| hilo | 0.785 | 0.110 | 0.715 | 0.88 | +32 | +26 |
+| darwin | 0.772 | 0.297 | 0.582 | 1.10 | +95 | +37 |
+| mobile | 0.641 | 0.164 | 0.569 | 0.77 | +70 | +108 |
+| penrith | 0.502 | 0.265 | 0.425 | 0.68 | +73 | +133 |
+
+**CSI improved at every location.** FAR dropped dramatically (Penrith 0.523→0.265, Darwin 0.571→0.297). Bias moved toward 1.0 everywhere - the detector is better calibrated than old scores suggested.
+
+**Critical insight - tuning direction has changed**: The old verifier made it look like the system was over-predicting (bias > 1.0 everywhere). The aligned verifier reveals the opposite at Penrith (bias=0.68) and Mobile (bias=0.77) - these locations are UNDER-detecting, not over-predicting. For Penrith, 133 old CNs became misses (rain within 15km we weren't detecting AND the old verifier didn't see). Tuning should focus on improving detection rate (T1: lower threshold, T4: fewer frames) rather than reducing false alarms (T2: higher min area, T3: tighter proximity).
+
+Full results in reports/full-v1-aligned/.
 
 ## Framework Improvements Done
 

--- a/docs/backtest-investigations.md
+++ b/docs/backtest-investigations.md
@@ -57,16 +57,68 @@ Constant-velocity cell projection assumption fails near terrain. Cells accelerat
 - Historical velocity profiles per location
 - Terrain-weighted arrival time adjustment
 
-## Framework Improvements Needed
+## QC Quick-Run Results (curated subset, 10 per category)
 
-### Compare feature
-`--compare <previous-dir>` to show POD/FAR/CSI deltas between runs. Save scorecards as JSON alongside markdown for machine-readable comparison.
+QC reduces false alarms but also kills real detections (cold clutter map).
+Full `--qc full` run in progress to get population-level numbers with warm clutter map.
 
-### Subset/tagging
-`--max-captures N` for quick iteration (~200 captures = ~1.5 days). Full run for significant changes. Tag output dirs meaningfully: `reports/baseline-qc-none`, `reports/qc-full`.
+| Location | FA (qc=none) | FA (qc=full) | Hits (qc=none) | Hits (qc=full) |
+|----------|--------------|--------------|----------------|----------------|
+| darwin | 20 | 5 | 10 | 12 |
+| penrith | 20 | 4 | 10 | 6 |
+| mobile | 20 | 5 | 10 | 10 |
+| cairns | 20 | 7 | 10 | 10 |
 
-### Verifier performance
-Quillayute (100% rain) took ~25min to verify. Verifier needs binary search or index for future capture lookup instead of linear scan.
+QC Bias dropped to 0.5-0.85 (under-forecasting). Need warmer clutter map or adjusted QC thresholds.
+
+## Tuning Backlog
+
+Each item is a hypothesis to test via quick subset run then validate with full run.
+
+### Detection thresholds
+
+- **T1: Intensity threshold** - currently 0.1. Lower catches more rain but increases noise. Test 0.05 and 0.15 to map the sensitivity curve.
+- **T2: Min cell area** - currently 5 pixels. Raising to 10-15 would filter small clutter blobs but might miss isolated cells. Test 10 and 20.
+- **T3: Proximity radius** - currently 128km. The verifier checks 10x10 pixels (~30km). Tightening detection proximity to 64km would reduce "near miss" false alarms but miss rain approaching from further out. Test 64km and 96km.
+- **T4: Min temporal frames** - currently 3 frames. Raising to 4-5 means a cell must be tracked for 30-50 minutes before triggering. Reduces pop-up false alarms but delays detection. Test 4 and 5.
+
+### QC pipeline
+
+- **Q1: Clutter maturity period** - currently 2 weeks (2016 cycles). In backtesting the clutter map starts cold and never matures. Test with a pre-warmed clutter map from a separate warmup run.
+- **Q2: QC confidence threshold** - QC multiplies intensity by confidence (0-1). Low-confidence cells get dimmed below the detection threshold. The effective threshold is `intensity * confidence >= 0.1`. Test raising/lowering the confidence floor.
+- **Q3: Texture vs temporal weights** - texture analysis catches speckle noise, temporal catches inconsistent cells. Current weights may over-penalize real rain with speckle-like texture (convective rain is inherently noisy). Test reducing texture weight.
+
+### Cell tracking
+
+- **C1: Max storm speed** - currently 150 km/h. Cells moving faster are rejected. Rarely a factor but could filter bogus high-speed matches.
+- **C2: Max angular variance** - currently ~90 degrees (in radians). Cells with inconsistent motion direction are rejected. Tightening reduces false matches but misses cells that change direction.
+- **C3: Velocity estimation window** - uses consecutive frame pairs. Averaging over 3-4 frame pairs would smooth noisy velocity estimates but add lag.
+
+### Arrival time
+
+- **A1: Closing distance fallback** - when cell velocity points away from location but distance is decreasing, we use a fallback arrival estimate. This catches "approaching but not pointed directly at us" scenarios. May be too generous - test disabling it.
+- **A2: Acceleration model** - constant velocity assumption fails near terrain. Test a simple linear acceleration model (velocity change between frame pairs).
+
+### Verification alignment
+
+- **V1: Align detection and verification proximity** - detector uses 128km, verifier uses ~30km. Many "false alarms" may be correct detections of rain that passes nearby but not overhead. Test with verifier proximity matching detector proximity.
+- **V2: Extended verification window** - currently 60min. Some "false alarms" may be rain that arrived after 60min. Test 90min and 120min windows to reclassify.
+
+## Framework Improvements Done
+
+- [x] Compare feature (`--compare`)
+- [x] Curated subset selection (`--generate-subset`, `--subset`)
+- [x] Tile decode optimisation (15ms → 1.2ms)
+- [x] Centroid extraction optimisation (12.5s → 25ms)
+- [x] Frame caching in replay and verifier
+
+## Framework Improvements Remaining
 
 ### Dry window skip
 Consecutive dry windows with unchanged latest frame produce identical detection results. Skip detection when the new frame is also dry - major speedup for locations with long dry periods.
+
+### Per-category comparison
+Compare should show deltas per category (hit rate for hits, FA rate for FAs) not just aggregate POD/FAR. The curated set is balanced so aggregate scores are always ~0.5.
+
+### Ground truth verifier
+BOM/METAR observation correlation with cell-path-aware station matching. Separate from radar-only verification.

--- a/scripts/backtest/verifier.py
+++ b/scripts/backtest/verifier.py
@@ -6,10 +6,11 @@ and checks whether any future capture shows rain at the location.
 from __future__ import annotations
 
 import logging
+import math
 from dataclasses import dataclass
 from datetime import datetime, timezone
 
-from custom_components.rain_incoming.const import INTENSITY_THRESHOLD
+from custom_components.rain_incoming.const import INTENSITY_THRESHOLD, PROXIMITY_RADIUS_KM
 from custom_components.rain_incoming.providers.base import BoundingBox
 from custom_components.rain_incoming.providers.rainviewer import _tile_bounds
 
@@ -23,11 +24,29 @@ _LOGGER = logging.getLogger(__name__)
 _GRID_SIZE = 512  # 2 tiles × 256 pixels per tile
 
 
+def _proximity_half_pixels(proximity_km: float, bounds: BoundingBox, grid_size: int) -> int:
+    """Convert a proximity radius in km to a half-width in pixels.
+
+    Uses the same formula as the detector's proximity_px calculation
+    (detector.py _pixel_size_km) so verification matches detection.
+    """
+    lat_span_km = (bounds.lat_max - bounds.lat_min) * 111.0
+    lon_span_km = (
+        (bounds.lon_max - bounds.lon_min)
+        * 111.0
+        * math.cos(math.radians((bounds.lat_min + bounds.lat_max) / 2))
+    )
+    km_per_row = lat_span_km / grid_size
+    km_per_col = lon_span_km / grid_size
+    avg_km_per_px = (km_per_row + km_per_col) / 2
+    return int(proximity_km / avg_km_per_px)
+
+
 @dataclass
 class VerifierConfig:
     lookahead_seconds: int = 3600
     intensity_threshold: float = INTENSITY_THRESHOLD
-    proximity_pixels: int = 10
+    proximity_km: float = PROXIMITY_RADIUS_KM
 
 
 class FutureRadarVerifier:
@@ -98,7 +117,7 @@ class FutureRadarVerifier:
         grid = frame.get_intensity_grid(bounds, _GRID_SIZE, _GRID_SIZE)
 
         loc_row, loc_col = _location_pixel(capture.lat, capture.lon, bounds, _GRID_SIZE)
-        half = config.proximity_pixels // 2
+        half = _proximity_half_pixels(config.proximity_km, bounds, _GRID_SIZE)
 
         row_min = max(0, loc_row - half)
         row_max = min(_GRID_SIZE, loc_row + half + 1)

--- a/tests/e2e/test_sensors_e2e.py
+++ b/tests/e2e/test_sensors_e2e.py
@@ -45,6 +45,9 @@ class TestIntegratedRainValidation:
         If previous_gif is provided, polls until the image differs from it
         (handles async_image returning stale cached data). Otherwise polls
         until the image has non-trivial content.
+
+        Raises AssertionError on timeout so the failure message is diagnostic
+        ("timed out waiting for render") rather than misleading ("images identical").
         """
         ha_client.set_mock_scenario(scenario)
         ha_client.wait_for_coordinator_cycle(BINARY_SENSOR, timeout=60)
@@ -55,7 +58,19 @@ class TestIntegratedRainValidation:
                 if previous_gif is None or gif != previous_gif:
                     return gif
             time.sleep(2)
-        return ha_client.get_image(entity_id)
+        gif = ha_client.get_image(entity_id)
+        if previous_gif is not None and gif == previous_gif:
+            raise AssertionError(
+                f"Timed out after {_IMAGE_POLL_TIMEOUT}s waiting for '{scenario}' "
+                f"image to differ from previous scenario. "
+                f"Image render may not have completed in time."
+            )
+        if not gif or len(gif) <= 1000:
+            raise AssertionError(
+                f"Timed out after {_IMAGE_POLL_TIMEOUT}s waiting for '{scenario}' "
+                f"image to have non-trivial content (got {len(gif) if gif else 0} bytes)."
+            )
+        return gif
 
     def test_rain_is_visible_on_radar_image(self, ha_client):
         """The radar image MUST look different with rain vs without rain."""

--- a/tests/unit/backtest/test_verifier.py
+++ b/tests/unit/backtest/test_verifier.py
@@ -445,7 +445,7 @@ class TestVerifyWithRealDryTiles:
 
 
 class TestVerifyProximityCheck:
-    """Rain within proximity_pixels of location is detected; rain outside is not."""
+    """Rain within the proximity neighborhood of location is detected; rain outside is not."""
 
     def _make_sparse_rain_tile(
         self, pixel_row: int, pixel_col: int, tile_x: int, tile_y: int
@@ -542,9 +542,9 @@ class TestVerifyProximityCheck:
 
         captures = [_make_capture(future_ts, tile_paths)]
         prediction = _make_prediction(window_end_ts=_BASE_TS, rain_incoming=False)
-        # Use a small proximity window (5 pixels) to ensure far rain is ignored
+        # 2km proximity - far rain at grid corner is well outside
         verifier = FutureRadarVerifier(
-            captures, VerifierConfig(lookahead_seconds=3600, proximity_pixels=5)
+            captures, VerifierConfig(lookahead_seconds=3600, proximity_km=2.0)
         )
         result = verifier.verify([prediction])
 
@@ -553,15 +553,16 @@ class TestVerifyProximityCheck:
         )
 
     def test_rain_at_edge_of_neighborhood_detected(self, tmp_path):
-        """Rain at exactly proximity_pixels from the location is detected."""
+        """Rain at the edge of the km-based proximity neighborhood is detected."""
         from scripts.backtest.verifier import FutureRadarVerifier, VerifierConfig
 
-        proximity = 10
+        # 5km at Melbourne resolution (~0.95 km/px) -> half = int(5.0/0.95) = 5 pixels
+        proximity_km = 5.0
+        expected_half = 5
         loc_row, loc_col = self._location_pixel_in_grid()
 
-        # Place rain at location + (proximity//2, 0) - within the NxN box
-        half = proximity // 2
-        target_row = loc_row + half
+        # Place rain at exactly 'expected_half' pixels from location - at the boundary
+        target_row = loc_row + expected_half
         target_col = loc_col
 
         # Map back to which tile and intra-tile pixel
@@ -589,24 +590,25 @@ class TestVerifyProximityCheck:
         captures = [_make_capture(future_ts, tile_paths)]
         prediction = _make_prediction(window_end_ts=_BASE_TS, rain_incoming=True)
         verifier = FutureRadarVerifier(
-            captures, VerifierConfig(lookahead_seconds=3600, proximity_pixels=proximity)
+            captures, VerifierConfig(lookahead_seconds=3600, proximity_km=proximity_km)
         )
         result = verifier.verify([prediction])
 
         assert result[0].actual_rain is True, (
             f"Rain at ({target_row},{target_col}) should be detected within "
-            f"{proximity}px neighborhood of ({loc_row},{loc_col})"
+            f"{proximity_km}km neighborhood of ({loc_row},{loc_col})"
         )
 
     def test_rain_just_outside_neighborhood_not_detected(self, tmp_path):
         """Rain just beyond the proximity window is not detected."""
         from scripts.backtest.verifier import FutureRadarVerifier, VerifierConfig
 
-        proximity = 5
+        # 2km at Melbourne resolution (~0.95 km/px) -> half = int(2.0/0.95) = 2 pixels
+        proximity_km = 2.0
         loc_row, loc_col = self._location_pixel_in_grid()
 
-        # Place rain just outside the window: loc_col + proximity (exclusive edge)
-        outside_col = loc_col + proximity + 5
+        # Place rain well outside the 2-pixel half-width
+        outside_col = loc_col + 10
         outside_row = loc_row
 
         tile_col = outside_col // 256
@@ -633,13 +635,13 @@ class TestVerifyProximityCheck:
         captures = [_make_capture(future_ts, tile_paths)]
         prediction = _make_prediction(window_end_ts=_BASE_TS, rain_incoming=False)
         verifier = FutureRadarVerifier(
-            captures, VerifierConfig(lookahead_seconds=3600, proximity_pixels=proximity)
+            captures, VerifierConfig(lookahead_seconds=3600, proximity_km=proximity_km)
         )
         result = verifier.verify([prediction])
 
         assert result[0].actual_rain is False, (
             f"Rain at ({outside_row},{outside_col}) should NOT be detected "
-            f"with proximity={proximity} and location at ({loc_row},{loc_col})"
+            f"with proximity_km={proximity_km} and location at ({loc_row},{loc_col})"
         )
 
     def test_multiple_predictions_verified_independently(self, tmp_path):
@@ -673,6 +675,123 @@ class TestVerifyProximityCheck:
 
 # ---------------------------------------------------------------------------
 # Frame caching: verifier must not rebuild frames for the same capture
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# 11. Km-based proximity: verifier should use km, not fixed pixels
+# ---------------------------------------------------------------------------
+
+
+class TestProximityKmComputation:
+    """The verifier should compute proximity in pixels from a km radius,
+    matching how the detector converts PROXIMITY_RADIUS_KM to pixels."""
+
+    def test_proximity_half_pixels_penrith_bounds(self):
+        """15km at Penrith resolution (~1.0 km/px) gives ~14 pixels."""
+        from scripts.backtest.verifier import _proximity_half_pixels
+        from custom_components.rain_incoming.providers.base import BoundingBox
+
+        # Penrith-like bounds: 2x2 tiles at zoom 7, lat -33.75
+        bounds = BoundingBox(
+            lat_min=-36.60, lat_max=-31.95,
+            lon_min=149.06, lon_max=154.69,
+        )
+        result = _proximity_half_pixels(15.0, bounds, 512)
+        assert result == 14
+
+    def test_proximity_half_pixels_equatorial_bounds(self):
+        """15km at equatorial resolution (~1.2 km/px) gives ~12 pixels."""
+        from scripts.backtest.verifier import _proximity_half_pixels
+        from custom_components.rain_incoming.providers.base import BoundingBox
+
+        # Darwin-like bounds: 2x2 tiles at zoom 7, lat -12.46
+        bounds = BoundingBox(
+            lat_min=-15.28, lat_max=-9.62,
+            lon_min=128.67, lon_max=134.30,
+        )
+        result = _proximity_half_pixels(15.0, bounds, 512)
+        assert result == 12
+
+    def test_proximity_half_pixels_high_latitude_bounds(self):
+        """15km at high-latitude resolution (~0.7 km/px) gives more pixels."""
+        from scripts.backtest.verifier import _proximity_half_pixels
+        from custom_components.rain_incoming.providers.base import BoundingBox
+
+        # Ketchikan actual tile bounds: 2x2 tiles at zoom 7, lat ~55.7
+        bounds = BoundingBox(
+            lat_min=54.1624, lat_max=57.3265,
+            lon_min=-135.0000, lon_max=-129.3750,
+        )
+        result = _proximity_half_pixels(15.0, bounds, 512)
+        assert result == 21
+
+
+class TestVerifierUsesKmProximity:
+    """VerifierConfig.proximity_km replaces proximity_pixels for consistent
+    km-based proximity across all locations."""
+
+    def test_config_defaults_to_production_proximity(self):
+        """VerifierConfig.proximity_km should default to PROXIMITY_RADIUS_KM."""
+        from scripts.backtest.verifier import VerifierConfig
+        from custom_components.rain_incoming.const import PROXIMITY_RADIUS_KM
+
+        config = VerifierConfig()
+        assert config.proximity_km == PROXIMITY_RADIUS_KM
+
+    def test_rain_within_15km_detected(self, tmp_path):
+        """Rain at ~10km from location (10 pixels at ~1 km/px) is detected
+        with the new 15km proximity but would have been missed with old 5px half."""
+        from scripts.backtest.verifier import FutureRadarVerifier, VerifierConfig
+
+        loc_row, loc_col = TestVerifyProximityCheck._location_pixel_in_grid(
+            TestVerifyProximityCheck()
+        )
+
+        # Place rain 10 pixels from location (~10km at Melbourne resolution)
+        # Old verifier: half=5 -> misses at 10px offset
+        # New verifier: 15km -> half~14px -> catches at 10px offset
+        target_row = loc_row + 10
+        target_col = loc_col
+
+        tile_col = target_col // 256
+        tile_row = target_row // 256
+        tx = 115 + tile_col
+        ty = 78 + tile_row
+        within_tile_col = target_col % 256
+        within_tile_row = target_row % 256
+
+        future_ts = _BASE_TS + 600
+        tile_dir = tmp_path / str(future_ts)
+        tile_dir.mkdir(parents=True, exist_ok=True)
+        tile_paths = {}
+        for (ttx, tty) in _ANALYSIS_TILES:
+            path = tile_dir / f"7_{ttx}_{tty}_s2.png"
+            if ttx == tx and tty == ty:
+                r, g, b, _ = PRECIP_COLOURS[0]
+                img = Image.new("RGBA", (256, 256), (0, 0, 0, 0))
+                img.putpixel((within_tile_col, within_tile_row), (r, g, b, 255))
+                buf = BytesIO()
+                img.save(buf, format="PNG")
+                path.write_bytes(buf.getvalue())
+            else:
+                path.write_bytes(_make_transparent_tile_png())
+            tile_paths[(ttx, tty)] = path
+
+        captures = [_make_capture(future_ts, tile_paths)]
+        prediction = _make_prediction(window_end_ts=_BASE_TS, rain_incoming=True)
+        # Use default proximity_km (15.0) - should detect rain at 10px offset
+        verifier = FutureRadarVerifier(captures, VerifierConfig(lookahead_seconds=3600))
+        result = verifier.verify([prediction])
+
+        assert result[0].actual_rain is True, (
+            f"Rain at ({target_row},{target_col}), 10px from location ({loc_row},{loc_col}), "
+            f"should be detected with 15km proximity (~14px half at Melbourne resolution)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 12. Frame caching
 # ---------------------------------------------------------------------------
 
 


### PR DESCRIPTION
## Summary

- Replaced `VerifierConfig.proximity_pixels` (fixed 10px, ~5km) with `proximity_km` (default 15.0, matching `PROXIMITY_RADIUS_KM`)
- Verifier now computes pixel radius from geographic bounds using the same formula as the detector
- Fixes a 2.5-4.4x proximity mismatch that created phantom false alarms across all locations
- Updated baseline results and investigation doc with corrected scores

## Results

CSI improved at every location. Biggest gains at locations with highest old FAR:

| Location | Old FAR | New FAR | Old CSI | New CSI | Old Bias | New Bias |
|----------|---------|---------|---------|---------|----------|----------|
| Darwin | 0.571 | 0.297 | 0.390 | 0.582 | 1.89 | 1.10 |
| Penrith | 0.523 | 0.265 | 0.379 | 0.425 | 1.36 | 0.68 |
| Quillayute | 0.388 | 0.135 | 0.588 | 0.735 | 1.53 | 0.96 |

Key insight: Penrith bias shifted from 1.36 (apparent over-prediction) to 0.68 (real under-detection). Tuning direction changes from "reduce false alarms" to "improve detection sensitivity."

## Test plan

- [x] Unit tests for `_proximity_half_pixels` at three latitudes (Penrith, Darwin, Ketchikan)
- [x] Unit test: `VerifierConfig` defaults to `PROXIMITY_RADIUS_KM`
- [x] Unit test: rain at 10km detected with 15km proximity
- [x] All 620 existing tests pass
- [x] Quick subset run validates reclassification
- [x] Full population run confirms CSI improvement at all locations

🤖 Generated with [Claude Code](https://claude.com/claude-code)