### PR TITLE
Tier 0 diagnostic trace + --inspect CLI

### DIFF
--- a/custom_components/rain_incoming/radar/detector.py
+++ b/custom_components/rain_incoming/radar/detector.py
@@ -63,6 +63,40 @@ class DetectionResult:
     last_labeled: np.ndarray | None = None  # labeled array of last frame's cells
 
 
+@dataclass
+class FrameDiagnostic:
+    """Diagnostic information for a single radar frame."""
+
+    cell_count: int
+
+
+@dataclass
+class TrackDiagnostic:
+    """Diagnostic information for a single tracked cell."""
+
+    frame_indices: list[int]
+    status: str
+    reason: str | None = None
+
+
+@dataclass
+class DecisionDiagnostic:
+    """The final decision made by detect()."""
+
+    rain_incoming: bool
+    arrival_minutes: float | None
+    rain_at_location: bool
+
+
+@dataclass
+class DiagnosticTrace:
+    """Accumulates per-frame diagnostic data during a detect() call."""
+
+    frames: list[FrameDiagnostic] = field(default_factory=list)
+    tracks: list[TrackDiagnostic] = field(default_factory=list)
+    decision: DecisionDiagnostic | None = None
+
+
 def _location_to_pixel(
     lat: float, lon: float, bounds: BoundingBox, width: int, height: int
 ) -> tuple[int, int]:
@@ -609,6 +643,7 @@ def detect(
     location: tuple[float, float],
     config: DetectorConfig,
     confidence_maps: list[np.ndarray] | None = None,
+    diagnostics: DiagnosticTrace | None = None,
 ) -> DetectionResult:
     """Run the full rain detection pipeline over a list of radar frames.
 
@@ -621,6 +656,12 @@ def detect(
     frame_count = len(frames)
 
     if frame_count < 2:
+        if diagnostics is not None:
+            diagnostics.decision = DecisionDiagnostic(
+                rain_incoming=False,
+                arrival_minutes=None,
+                rain_at_location=False,
+            )
         return DetectionResult(
             rain_incoming=False,
             arrival_time=None,
@@ -632,6 +673,11 @@ def detect(
     confidence = Confidence.DEGRADED if frame_count < 3 else Confidence.NORMAL
 
     analysis = _prepare_frame_analysis(frames, config, confidence_maps)
+
+    if diagnostics is not None:
+        for centroids in analysis.per_frame_centroids:
+            diagnostics.frames.append(FrameDiagnostic(cell_count=len(centroids)))
+
     bounds = config.analysis_bounds
     W, H = config.grid_width, config.grid_height
 
@@ -648,6 +694,23 @@ def detect(
     max_match_dist = max(W, H) * 0.25  # allow up to 25% of grid size per frame
     all_tracks = _build_cell_tracks(analysis.per_frame_centroids, max_match_dist)
 
+    if diagnostics is not None:
+        _last_frame_idx = frame_count - 1
+        for track in all_tracks:
+            if len(track) < config.min_temporal_frames:
+                track_status, track_reason = "dropped", "too_short"
+            elif track[-1][0] != _last_frame_idx:
+                track_status, track_reason = "dropped", "ended_early"
+            else:
+                track_status, track_reason = "accepted", None
+            diagnostics.tracks.append(
+                TrackDiagnostic(
+                    frame_indices=[entry[0] for entry in track],
+                    status=track_status,
+                    reason=track_reason,
+                )
+            )
+
     last_frame_idx = frame_count - 1
     valid_tracks = [
         t for t in all_tracks
@@ -657,6 +720,18 @@ def detect(
     last_labeled = analysis.per_frame_labeled[-1]
 
     if not valid_tracks:
+        if diagnostics is not None:
+            no_track_rain_incoming = rain_at_location is not None
+            no_track_arrival_minutes = (
+                (frames[rain_at_location[0]].timestamp - frames[-1].timestamp).total_seconds() / 60.0
+                if rain_at_location is not None
+                else None
+            )
+            diagnostics.decision = DecisionDiagnostic(
+                rain_incoming=no_track_rain_incoming,
+                arrival_minutes=no_track_arrival_minutes,
+                rain_at_location=rain_at_location is not None,
+            )
         return _no_tracks_result(
             rain_at_location, frames, confidence, frame_count, last_labeled,
         )
@@ -680,6 +755,15 @@ def detect(
     )
 
     rain_incoming = earliest_arrival is not None
+    if diagnostics is not None:
+        arrival_minutes = None
+        if earliest_arrival is not None:
+            arrival_minutes = (earliest_arrival - frames[-1].timestamp).total_seconds() / 60.0
+        diagnostics.decision = DecisionDiagnostic(
+            rain_incoming=rain_incoming,
+            arrival_minutes=arrival_minutes,
+            rain_at_location=rain_at_location is not None,
+        )
     return DetectionResult(
         rain_incoming=rain_incoming,
         arrival_time=earliest_arrival,

--- a/scripts/backtest/cli.py
+++ b/scripts/backtest/cli.py
@@ -8,6 +8,8 @@ from the command line::
 from __future__ import annotations
 
 import argparse
+import dataclasses
+import json
 import sys
 from pathlib import Path
 
@@ -166,6 +168,13 @@ def main(argv: list[str] | None = None) -> None:
         default=False,
         help="Enable acceleration-aware cell projection (experimental)",
     )
+    parser.add_argument(
+        "--inspect",
+        nargs=2,
+        metavar=("LOCATION", "TIMESTAMP"),
+        default=None,
+        help="Run detect() on a single window and print the diagnostic trace as JSON. Args: location_name, window_end_ts",
+    )
 
     args = parser.parse_args(argv)
 
@@ -189,6 +198,30 @@ def main(argv: list[str] | None = None) -> None:
     if not captures_dir.is_dir():
         print(f"Error: {captures_dir} not found", file=sys.stderr)
         sys.exit(1)
+
+    # Handle --inspect mode: run detect() on a single window and dump the trace as JSON
+    if args.inspect:
+        location_name, ts_str = args.inspect
+        window_end_ts = int(ts_str)
+        loc_dir = captures_dir / location_name
+        captures = load_captures(loc_dir)
+        replay_kwargs = dict(
+            window_size=args.window_size,
+            max_gap_seconds=args.max_gap_seconds,
+            qc_enabled=(args.qc == "full"),
+            lookahead_seconds=args.lookahead_minutes * 60,
+        )
+        if args.intensity_threshold is not None:
+            replay_kwargs["intensity_threshold"] = args.intensity_threshold
+        if args.min_cell_area is not None:
+            replay_kwargs["min_cell_area_pixels"] = args.min_cell_area
+        if args.use_acceleration:
+            replay_kwargs["use_acceleration"] = True
+        config = ReplayConfig(**replay_kwargs)
+        engine = ReplayEngine(config)
+        _prediction, trace = engine.inspect_window(captures, window_end_ts=window_end_ts)
+        print(json.dumps(dataclasses.asdict(trace), indent=2, default=str))
+        return
 
     # Discover locations
     if args.locations == "all":

--- a/scripts/backtest/replay.py
+++ b/scripts/backtest/replay.py
@@ -30,6 +30,7 @@ from custom_components.rain_incoming.providers.base import BoundingBox
 from custom_components.rain_incoming.providers.rainviewer import _tile_bounds
 from custom_components.rain_incoming.radar.detector import (
     DetectorConfig,
+    DiagnosticTrace,
     detect,
 )
 from custom_components.rain_incoming.radar.qc.clutter_map import (
@@ -356,3 +357,50 @@ class ReplayEngine:
             predictions.append(_to_prediction(result, frames, window))
 
         return predictions
+
+    def inspect_window(
+        self,
+        captures: list[CaptureRecord],
+        window_end_ts: int,
+    ) -> tuple[PredictionRecord, DiagnosticTrace]:
+        """Run detect() on the window ending at window_end_ts and return the trace.
+
+        Raises ValueError if the timestamp isn't found or there aren't enough captures.
+        """
+        config = self._config
+        window_size = config.window_size
+
+        sorted_captures = sorted(captures, key=lambda r: r.frame_ts)
+        ts_list = [r.frame_ts for r in sorted_captures]
+
+        try:
+            end_idx = ts_list.index(window_end_ts)
+        except ValueError:
+            raise ValueError(f"window_end_ts={window_end_ts} not found in captures")
+
+        if end_idx < window_size - 1:
+            raise ValueError(
+                f"Not enough captures before ts={window_end_ts} "
+                f"(need {window_size}, have {end_idx + 1})"
+            )
+
+        window = sorted_captures[end_idx - window_size + 1 : end_idx + 1]
+        frames = [_frame_from_record(r) for r in window]
+        detector_config = _build_detector_config(window[0], config)
+
+        confidence_maps: list[np.ndarray] | None = None
+        if config.qc_enabled:
+            confidence_maps = _compute_confidence_maps(
+                frames, detector_config, None, 0.0
+            )
+
+        trace = DiagnosticTrace()
+        result = detect(
+            frames=frames,
+            location=(window[0].lat, window[0].lon),
+            config=detector_config,
+            confidence_maps=confidence_maps,
+            diagnostics=trace,
+        )
+
+        return _to_prediction(result, frames, window), trace

--- a/tests/unit/backtest/test_cli.py
+++ b/tests/unit/backtest/test_cli.py
@@ -736,3 +736,71 @@ class TestIntensityThresholdFlag:
         config = call_args[1].get("config") or (call_args[0][1] if len(call_args[0]) > 1 else None)
         assert config is not None, "VerifierConfig not passed to FutureRadarVerifier"
         assert config.intensity_threshold == 0.05
+
+
+# ---------------------------------------------------------------------------
+# Test: --inspect <location> <timestamp> prints diagnostic trace as JSON
+# ---------------------------------------------------------------------------
+
+
+class TestMainInspectMode:
+    def test_main_inspect_prints_trace_as_json(self, tmp_path: Path, capsys) -> None:
+        """--inspect LOCATION TIMESTAMP prints diagnostic JSON to stdout."""
+        from scripts.backtest.cli import main
+        from custom_components.rain_incoming.radar.detector import (
+            DiagnosticTrace,
+            FrameDiagnostic,
+            TrackDiagnostic,
+            DecisionDiagnostic,
+        )
+
+        data_dir = tmp_path / "data"
+        captures_dir = data_dir / "captures"
+        _make_location_dir(captures_dir, "loc1")
+
+        prediction = _make_prediction(rain_incoming=True, arrival_minutes=15.0)
+        trace = DiagnosticTrace(
+            frames=[FrameDiagnostic(cell_count=1)],
+            tracks=[TrackDiagnostic(frame_indices=[0, 1, 2], status="accepted")],
+            decision=DecisionDiagnostic(
+                rain_incoming=True, arrival_minutes=15.0, rain_at_location=False
+            ),
+        )
+
+        with patch("scripts.backtest.cli.ReplayEngine") as MockEngine:
+            instance = MockEngine.return_value
+            instance.inspect_window.return_value = (prediction, trace)
+
+            main([
+                "--data-dir", str(data_dir),
+                "--inspect", "loc1", "1776700000",
+            ])
+
+        captured = capsys.readouterr()
+        # Output should contain JSON with the trace structure
+        # The CLI should print a single JSON object that parses cleanly
+        # Look for a parseable JSON block in stdout
+        out = captured.out
+        # Find the first '{' and last '}' and parse the slice
+        start = out.find("{")
+        end = out.rfind("}")
+        assert start >= 0 and end > start, f"No JSON found in output:\n{out}"
+        parsed = json.loads(out[start : end + 1])
+
+        assert "frames" in parsed
+        assert len(parsed["frames"]) == 1
+        assert parsed["frames"][0]["cell_count"] == 1
+        assert "tracks" in parsed
+        assert parsed["tracks"][0]["status"] == "accepted"
+        assert "decision" in parsed
+        assert parsed["decision"]["rain_incoming"] is True
+        assert parsed["decision"]["arrival_minutes"] == 15.0
+
+        # Verify inspect_window was called with the right timestamp
+        instance.inspect_window.assert_called_once()
+        call_args = instance.inspect_window.call_args
+        # window_end_ts should be 1776700000
+        assert (
+            1776700000 in call_args.args
+            or call_args.kwargs.get("window_end_ts") == 1776700000
+        )

--- a/tests/unit/backtest/test_replay.py
+++ b/tests/unit/backtest/test_replay.py
@@ -16,6 +16,9 @@ from scripts.backtest.replay import PredictionRecord, ReplayConfig, ReplayEngine
 from custom_components.rain_incoming.radar.detector import (
     Confidence,
     DetectionResult,
+    DiagnosticTrace,
+    FrameDiagnostic,
+    DecisionDiagnostic,
 )
 
 
@@ -496,3 +499,43 @@ class TestReplayManifestOnlyLoadNeededCaptures:
             f"_frame_from_record called {mock_frame.call_count} times for "
             f"2 manifest windows - should only build frames for needed captures, not all {len(captures)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# 9. inspect_window: extract diagnostic trace for a target window
+# ---------------------------------------------------------------------------
+
+
+class TestInspectWindow:
+    def test_inspect_window_returns_prediction_and_trace_for_target_window(self) -> None:
+        """inspect_window runs detect() on the window ending at window_end_ts.
+
+        Returns both the PredictionRecord and the DiagnosticTrace that was
+        passed to detect()."""
+        captures = _make_records(8)
+        target_ts = captures[-1].frame_ts
+
+        def populate_trace(frames, location, config, confidence_maps=None, diagnostics=None):
+            """Mock detect() that populates the trace if provided."""
+            if diagnostics is not None:
+                for _ in frames:
+                    diagnostics.frames.append(FrameDiagnostic(cell_count=2))
+                diagnostics.decision = DecisionDiagnostic(
+                    rain_incoming=True,
+                    arrival_minutes=15.0,
+                    rain_at_location=False,
+                )
+            return _mock_detect_result(rain_incoming=True)
+
+        engine = ReplayEngine(ReplayConfig(qc_enabled=False))
+        with patch("scripts.backtest.replay.detect", side_effect=populate_trace):
+            prediction, trace = engine.inspect_window(captures, window_end_ts=target_ts)
+
+        assert isinstance(prediction, PredictionRecord)
+        assert prediction.rain_incoming is True
+        assert isinstance(trace, DiagnosticTrace)
+        assert len(trace.frames) == 8
+        assert trace.frames[0].cell_count == 2
+        assert trace.decision is not None
+        assert trace.decision.rain_incoming is True
+        assert trace.decision.arrival_minutes == 15.0

--- a/tests/unit/radar/test_detector.py
+++ b/tests/unit/radar/test_detector.py
@@ -611,3 +611,209 @@ class TestClosingDistanceFallback:
         frames = self._make_oblique_frames(cfg, positions)
         result = detect(frames=frames, location=(LAT, LON), config=cfg)
         assert result.rain_incoming is False
+
+
+class TestDetectDiagnostics:
+    """Tests for the diagnostic trace feature that exposes frame analysis details."""
+
+    def test_diagnostics_trace_records_cell_counts_per_frame(self):
+        """When detect() is called with diagnostics=DiagnosticTrace(), the trace
+        should record the cell count found in each frame.
+        """
+        from custom_components.rain_incoming.radar.detector import (
+            DiagnosticTrace,
+        )
+
+        cfg = default_config()
+        # Frame 0: empty grid (0 cells)
+        grid0 = np.zeros((64, 64), dtype=np.float32)
+        frame0 = make_frame(ts(-20), grid0, cfg.analysis_bounds)
+
+        # Frame 1: empty grid (0 cells)
+        grid1 = np.zeros((64, 64), dtype=np.float32)
+        frame1 = make_frame(ts(-10), grid1, cfg.analysis_bounds)
+
+        # Frame 2: one rain cell (2x2 patch at row 20, col 20 - away from location)
+        grid2 = np.zeros((64, 64), dtype=np.float32)
+        grid2[20:22, 20:22] = 0.5
+        frame2 = make_frame(ts(0), grid2, cfg.analysis_bounds)
+
+        frames = [frame0, frame1, frame2]
+        trace = DiagnosticTrace()
+
+        result = detect(frames=frames, location=(LAT, LON), config=cfg, diagnostics=trace)
+
+        # Verify trace was populated
+        assert len(trace.frames) == 3
+        assert trace.frames[0].cell_count == 0
+        assert trace.frames[1].cell_count == 0
+        assert trace.frames[2].cell_count == 1
+
+    def test_diagnostics_trace_records_tracks_with_frame_indices(self):
+        """When detect() runs on frames containing a single rain cell moving across
+        3 frames, the trace's tracks list should contain one TrackDiagnostic whose
+        frame_indices is [0, 1, 2].
+        """
+        from custom_components.rain_incoming.radar.detector import (
+            DiagnosticTrace,
+            TrackDiagnostic,
+        )
+
+        cfg = default_config()
+        # Build 3 frames with a single cell moving east by 2 pixels per frame
+        # Frame 0: cell at columns 20-21 (2x2 patch at row 20)
+        grid0 = np.zeros((64, 64), dtype=np.float32)
+        grid0[20:22, 20:22] = 0.5
+        frame0 = make_frame(ts(-20), grid0, cfg.analysis_bounds)
+
+        # Frame 1: cell at columns 22-23
+        grid1 = np.zeros((64, 64), dtype=np.float32)
+        grid1[20:22, 22:24] = 0.5
+        frame1 = make_frame(ts(-10), grid1, cfg.analysis_bounds)
+
+        # Frame 2: cell at columns 24-25
+        grid2 = np.zeros((64, 64), dtype=np.float32)
+        grid2[20:22, 24:26] = 0.5
+        frame2 = make_frame(ts(0), grid2, cfg.analysis_bounds)
+
+        frames = [frame0, frame1, frame2]
+        trace = DiagnosticTrace()
+
+        result = detect(frames=frames, location=(LAT, LON), config=cfg, diagnostics=trace)
+
+        # Verify trace.tracks was populated with the cell track
+        assert len(trace.tracks) == 1
+        assert trace.tracks[0].frame_indices == [0, 1, 2]
+
+    def test_diagnostics_records_dropped_track_too_short(self):
+        """When a cell appears only in the last frame (single-frame track),
+        the trace should record that track with status='dropped' and reason='too_short'.
+
+        The detector requires min_temporal_frames=2. A single-frame track in the last
+        frame meets the 'ends on last frame' condition but fails the minimum duration check.
+        """
+        from custom_components.rain_incoming.radar.detector import (
+            DiagnosticTrace,
+        )
+
+        cfg = default_config()
+        # Frame 0: empty grid (no cells)
+        grid0 = np.zeros((64, 64), dtype=np.float32)
+        frame0 = make_frame(ts(-20), grid0, cfg.analysis_bounds)
+
+        # Frame 1: empty grid (no cells)
+        grid1 = np.zeros((64, 64), dtype=np.float32)
+        frame1 = make_frame(ts(-10), grid1, cfg.analysis_bounds)
+
+        # Frame 2: one rain cell (2x2 patch at row 20, col 20 - away from location)
+        grid2 = np.zeros((64, 64), dtype=np.float32)
+        grid2[20:22, 20:22] = 0.5
+        frame2 = make_frame(ts(0), grid2, cfg.analysis_bounds)
+
+        frames = [frame0, frame1, frame2]
+        trace = DiagnosticTrace()
+
+        result = detect(frames=frames, location=(LAT, LON), config=cfg, diagnostics=trace)
+
+        # The detector builds one track from the single cell in the last frame
+        assert len(trace.tracks) == 1
+        # Track contains only frame 2
+        assert trace.tracks[0].frame_indices == [2]
+        # Track is dropped because it's too short (only 1 frame, requires min 2)
+        assert trace.tracks[0].status == "dropped"
+        assert trace.tracks[0].reason == "too_short"
+
+    def test_diagnostics_records_dropped_track_ended_early(self):
+        """When a cell appears in early frames but vanishes before the last frame,
+        the trace should record that track with status='dropped' and reason='ended_early'.
+
+        A track that meets the minimum temporal duration but ends before the last frame
+        is rejected because it doesn't span the observation window.
+        """
+        from custom_components.rain_incoming.radar.detector import (
+            DiagnosticTrace,
+        )
+
+        cfg = default_config()
+        # Frame 0: cell at row 20, columns 20-21
+        grid0 = np.zeros((64, 64), dtype=np.float32)
+        grid0[20:22, 20:22] = 0.5
+        frame0 = make_frame(ts(-20), grid0, cfg.analysis_bounds)
+
+        # Frame 1: cell at row 20, columns 22-23 (moved 2px east)
+        grid1 = np.zeros((64, 64), dtype=np.float32)
+        grid1[20:22, 22:24] = 0.5
+        frame1 = make_frame(ts(-10), grid1, cfg.analysis_bounds)
+
+        # Frame 2 (last): empty grid (cell vanished)
+        grid2 = np.zeros((64, 64), dtype=np.float32)
+        frame2 = make_frame(ts(0), grid2, cfg.analysis_bounds)
+
+        frames = [frame0, frame1, frame2]
+        trace = DiagnosticTrace()
+
+        result = detect(frames=frames, location=(LAT, LON), config=cfg, diagnostics=trace)
+
+        # The detector builds one track from frames 0-1
+        assert len(trace.tracks) == 1
+        # Track spans frames 0-1 (len=2, meets min_temporal_frames=2)
+        assert trace.tracks[0].frame_indices == [0, 1]
+        # But it ends on frame 1, not frame 2 (last_frame_idx), so it's dropped
+        assert trace.tracks[0].status == "dropped"
+        assert trace.tracks[0].reason == "ended_early"
+
+    def test_diagnostics_records_decision_for_approaching_rain(self):
+        """When detect() predicts incoming rain from an approaching cell, the trace's
+        decision field should record rain_incoming=True and an arrival_minutes value
+        matching the result.
+        """
+        from custom_components.rain_incoming.radar.detector import (
+            DiagnosticTrace,
+        )
+
+        cfg = default_config()
+        # Build 3 frames with a single cell moving east toward the location.
+        # Location is at pixel (32, 32). Cell starts at col 20 and moves right by 2 px/frame.
+        # At ~52 km/h this stays under the 120 km/h speed cap.
+        # It will reach the location within the lookahead window.
+        # Frame 0: cell at row 20, columns 20-21 (intensity 0.5)
+        grid0 = np.zeros((64, 64), dtype=np.float32)
+        grid0[30:33, 20:23] = 0.5
+        frame0 = make_frame(ts(-20), grid0, cfg.analysis_bounds)
+
+        # Frame 1: cell at row 20, columns 22-23 (moved 2px east)
+        grid1 = np.zeros((64, 64), dtype=np.float32)
+        grid1[30:33, 22:25] = 0.5
+        frame1 = make_frame(ts(-10), grid1, cfg.analysis_bounds)
+
+        # Frame 2: cell at row 20, columns 24-25 (moved 2px east)
+        grid2 = np.zeros((64, 64), dtype=np.float32)
+        grid2[30:33, 24:27] = 0.5
+        frame2 = make_frame(ts(0), grid2, cfg.analysis_bounds)
+
+        frames = [frame0, frame1, frame2]
+        trace = DiagnosticTrace()
+
+        result = detect(frames=frames, location=(LAT, LON), config=cfg, diagnostics=trace)
+
+        # Verify the detector predicted rain incoming (approaching cell detected)
+        assert result.rain_incoming is True
+        assert result.arrival_time is not None
+
+        # Verify trace.decision was populated
+        assert trace.decision is not None
+
+        # Mirror the result's rain_incoming status
+        assert trace.decision.rain_incoming == result.rain_incoming
+
+        # Verify arrival_minutes matches the calculation:
+        # (arrival_time - last_frame_timestamp).total_seconds() / 60.0
+        expected_arrival_minutes = (
+            result.arrival_time - frames[-1].timestamp
+        ).total_seconds() / 60.0
+        assert trace.decision.arrival_minutes == pytest.approx(
+            expected_arrival_minutes, abs=0.1
+        )
+
+        # Verify rain_at_location mirrors the result
+        assert trace.decision.rain_at_location == result.rain_at_location


### PR DESCRIPTION
## Summary

Foundation for fast iteration on detector variants. Lets you see exactly what the detector saw on a specific window and why it made its decision.

### What this adds

- **`DiagnosticTrace` dataclass** in detector.py. Optional sink that `detect()` populates when provided. Production code path unchanged when `diagnostics=None` (default).
- **Per-frame info**: cell counts (`FrameDiagnostic`)
- **Per-track info**: frame_indices, status (accepted/dropped), reason (too_short/ended_early) (`TrackDiagnostic`)
- **Final decision**: rain_incoming, arrival_minutes, rain_at_location (`DecisionDiagnostic`)
- **`ReplayEngine.inspect_window(captures, window_end_ts)`**: returns `(PredictionRecord, DiagnosticTrace)` for a single window
- **`--inspect LOCATION TIMESTAMP` CLI**: prints the trace as JSON

### Usage

```bash
python -m scripts.backtest --data-dir backtest_data --inspect penrith 1776345600
```

Outputs JSON with frames/tracks/decision so you can see exactly what the detector did.

### What's missing (deferred to later slices)

- Eval-level rejection reasons (incoherent, too_fast) - the rejection rationale currently only covers structural reasons (too_short, ended_early)
- Cell-level details (centroids, areas, intensities) - currently only counts
- Velocity/projection details per track
- Human-readable summary output (currently JSON only)

These are quick adds when needed. The current trace is enough to investigate "did the detector see the cell?" and "what was the final decision?" - the most common questions.

### TDD process

Built across 6 vertical TDD slices, each one test → minimum impl → next test. Pair: Sonnet 4.6 implementer, Haiku 4.5 test-writer, Opus 4.7 orchestrator.

## Test plan

- [x] 6 new unit tests covering each slice (frames, tracks, status, ended_early, decision, inspect_window)
- [x] 1 new CLI integration test for --inspect
- [x] All 524 unit tests pass, 110 integration tests pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)