### PR TITLE
Phase 6A intensity trend + Phase 3B frame scaling + Tier 1 inspect-set

### DIFF
--- a/custom_components/rain_incoming/radar/detector.py
+++ b/custom_components/rain_incoming/radar/detector.py
@@ -49,6 +49,7 @@ class DetectorConfig:
     grid_width: int
     grid_height: int
     use_acceleration: bool = False
+    use_intensity_trend: bool = False
 
 
 @dataclass
@@ -216,6 +217,11 @@ def _check_rain_at_location(
 # Minimum cell confidence to report rain_incoming
 _MIN_CELL_CONFIDENCE = 0.35
 
+# Intensity ratio (final / initial frame in track) below which a cell is
+# considered to be dissipating and is suppressed when use_intensity_trend
+# is enabled. 0.5 means "intensity has at least halved across the track."
+_INTENSITY_DECLINE_THRESHOLD = 0.5
+
 
 def _cell_mean_confidence(
     label: int,
@@ -294,6 +300,22 @@ def _evaluate_overhead_cell(
     return tracked, arrival_dt, intensity_contribution
 
 
+def _intensity_at_track_entry(
+    track: list[_TrackEntry],
+    idx: int,
+    per_frame_grids: list[np.ndarray],
+    per_frame_labeled_all: list[np.ndarray],
+) -> float:
+    """Return the max pixel intensity of the cell at track[idx] in its frame."""
+    frame_idx, label, _ = track[idx]
+    grid = per_frame_grids[frame_idx]
+    labeled = per_frame_labeled_all[frame_idx]
+    cell_pixels = grid[labeled == label]
+    if cell_pixels.size == 0:
+        return 0.0
+    return float(cell_pixels.max())
+
+
 def _evaluate_approaching_cell(
     track: list[_TrackEntry],
     frames: list[RadarFrame],
@@ -307,6 +329,8 @@ def _evaluate_approaching_cell(
     last_labeled: np.ndarray,
     last_conf_map: np.ndarray | None,
     last_frame_time: datetime,
+    per_frame_grids: list[np.ndarray] | None = None,
+    per_frame_labeled_all: list[np.ndarray] | None = None,
 ) -> tuple[TrackedCell, datetime | None, float] | None:
     """Evaluate a tracked cell that is not yet overhead - approaching.
 
@@ -342,6 +366,13 @@ def _evaluate_approaching_cell(
     speed_kmh_val = math.sqrt(vy_km_s**2 + vx_km_s**2) * 3600
     if speed_kmh_val > config.max_storm_speed_kmh:
         return None
+
+    # Suppress dissipating cells when intensity trend check is enabled
+    if config.use_intensity_trend and per_frame_grids is not None and per_frame_labeled_all is not None:
+        initial_intensity = _intensity_at_track_entry(track, 0, per_frame_grids, per_frame_labeled_all)
+        final_intensity = _intensity_at_track_entry(track, -1, per_frame_grids, per_frame_labeled_all)
+        if initial_intensity > 0 and final_intensity / initial_intensity < _INTENSITY_DECLINE_THRESHOLD:
+            return None
 
     # Compute acceleration if enabled
     ay, ax = 0.0, 0.0
@@ -585,6 +616,8 @@ def _process_tracks(
     last_grid: np.ndarray,
     last_labeled: np.ndarray,
     last_conf_map: np.ndarray | None,
+    per_frame_grids: list[np.ndarray] | None = None,
+    per_frame_labeled_all: list[np.ndarray] | None = None,
 ) -> tuple[list[TrackedCell], datetime | None, float]:
     """Evaluate each valid track and accumulate earliest arrival and max intensity."""
     last_frame_time = frames[-1].timestamp
@@ -607,6 +640,8 @@ def _process_tracks(
                 track, frames, config, loc_row, loc_col, proximity_px,
                 km_per_row, km_per_col, last_grid, last_labeled, last_conf_map,
                 last_frame_time,
+                per_frame_grids=per_frame_grids,
+                per_frame_labeled_all=per_frame_labeled_all,
             )
 
         if result is None:
@@ -748,6 +783,8 @@ def detect(
         loc_row, loc_col, proximity_px_f,
         km_per_row, km_per_col,
         analysis.grids[-1], last_labeled, last_conf_map,
+        per_frame_grids=analysis.grids,
+        per_frame_labeled_all=analysis.per_frame_labeled,
     )
 
     earliest_arrival, max_intensity = _merge_location_rain(

--- a/custom_components/rain_incoming/radar/detector.py
+++ b/custom_components/rain_incoming/radar/detector.py
@@ -50,6 +50,7 @@ class DetectorConfig:
     grid_height: int
     use_acceleration: bool = False
     use_intensity_trend: bool = False
+    frame_scale_by_lookahead: bool = False
 
 
 @dataclass
@@ -673,6 +674,25 @@ def _merge_location_rain(
     return earliest_arrival, max(max_intensity, rain_intensity)
 
 
+def _effective_min_temporal_frames(config: DetectorConfig) -> int:
+    """Compute the effective min_temporal_frames, optionally scaled by lookahead.
+
+    Longer-range predictions need more evidence (more frames in the track) to
+    avoid false positives from transient signals. The user's explicit
+    config.min_temporal_frames is a floor.
+    """
+    if not config.frame_scale_by_lookahead:
+        return config.min_temporal_frames
+    lookahead_min = config.lookahead_seconds / 60.0
+    if lookahead_min <= 20:
+        scaled = 2
+    elif lookahead_min <= 40:
+        scaled = 3
+    else:
+        scaled = 4
+    return max(config.min_temporal_frames, scaled)
+
+
 def detect(
     frames: list[RadarFrame],
     location: tuple[float, float],
@@ -747,9 +767,10 @@ def detect(
             )
 
     last_frame_idx = frame_count - 1
+    effective_min = _effective_min_temporal_frames(config)
     valid_tracks = [
         t for t in all_tracks
-        if len(t) >= config.min_temporal_frames and t[-1][0] == last_frame_idx
+        if len(t) >= effective_min and t[-1][0] == last_frame_idx
     ]
 
     last_labeled = analysis.per_frame_labeled[-1]

--- a/custom_components/rain_incoming/radar/detector.py
+++ b/custom_components/rain_incoming/radar/detector.py
@@ -79,6 +79,9 @@ class TrackDiagnostic:
     frame_indices: list[int]
     status: str
     reason: str | None = None
+    velocity_kmh: float | None = None
+    initial_intensity: float | None = None
+    final_intensity: float | None = None
 
 
 @dataclass
@@ -758,11 +761,20 @@ def detect(
                 track_status, track_reason = "dropped", "ended_early"
             else:
                 track_status, track_reason = "accepted", None
+            diag_velocity: float | None = None
+            if len(track) >= 2:
+                speed, _ = _track_velocity_kmh_bearing(track, frames, km_per_row, km_per_col)
+                diag_velocity = speed
+            diag_initial = _intensity_at_track_entry(track, 0, analysis.grids, analysis.per_frame_labeled)
+            diag_final = _intensity_at_track_entry(track, -1, analysis.grids, analysis.per_frame_labeled)
             diagnostics.tracks.append(
                 TrackDiagnostic(
                     frame_indices=[entry[0] for entry in track],
                     status=track_status,
                     reason=track_reason,
+                    velocity_kmh=diag_velocity,
+                    initial_intensity=diag_initial,
+                    final_intensity=diag_final,
                 )
             )
 

--- a/docs/backtest-investigations.md
+++ b/docs/backtest-investigations.md
@@ -185,6 +185,38 @@ explored. Currently does not provide a path to reducing Penrith FAs.
 **Next direction**: overhead transient FAs need a different approach -
 satellite cloud check, forecast PoP, or smarter clutter detection.
 
+## Phase 3B: Frame-Scaled min_temporal_frames (NEUTRAL)
+
+Hypothesis: longer-range predictions need more evidence. Scale `min_temporal_frames`
+by lookahead horizon: 2 frames at <=20min, 3 at <=40min, 4 at >40min.
+
+**Result on Penrith at 30min lookahead**: POD 0.581 vs control 0.588 (-0.007),
+FAR 0.232 vs 0.237 (-0.005), CSI 0.494 vs 0.497 (-0.003). Net 2 fewer hits, 2
+fewer FAs - essentially neutral.
+
+At 30min lookahead, the flag scales to require 3 frames. Two short tracks were
+filtered: one was a true hit, one was an FA. Net wash.
+
+**Status**: kept as opt-in (`--frame-scale-by-lookahead`). Could matter more at
+longer lookaheads (60min would require 4 frames) but current default is 30min
+where the impact is tiny.
+
+## Tier 0 Diagnostic Findings (early)
+
+Inspecting Penrith FA window 1776388200 (predicted +11min, no rain arrived):
+- 49 tracks built across 8 frames
+- 8 marked "accepted" (passed structural checks)
+- BUT 2 of those have impossible velocities (212 km/h, 322 km/h) - way over the
+  120 km/h speed cap
+- These get rejected later by `_evaluate_approaching_cell`'s speed check, but
+  they were noise-matched cells the tracker linked across frames despite being
+  physically impossible
+
+**Implication**: noise tracking matches cells across frames creating phantom
+high-speed tracks. The downstream speed cap catches them but they consume
+detector cycles. Could pre-filter at the matching step or expose the
+post-evaluation rejection in Tier 0 to make the noise visible.
+
 ## Framework Improvements Done
 
 - [x] Compare feature (`--compare`)

--- a/docs/backtest-investigations.md
+++ b/docs/backtest-investigations.md
@@ -158,6 +158,33 @@ The original V1 hypothesis incorrectly stated "128km vs 30km" - 128km is a radar
 
 Full results in reports/full-v1-aligned/.
 
+## Phase 6A: Intensity Trend Filter (NEUTRAL)
+
+Hypothesis: 73% of Penrith FAs are real cells that dissipate crossing the Blue
+Mountains. If we suppress detection of cells with sharply declining intensity
+(final/initial < 0.5), we should reduce these FAs.
+
+**Result: no measurable effect at threshold 0.5.** Penrith with intensity trend
+on at 30min lookahead: POD 0.588, FAR 0.234, CSI 0.499. Same Penrith with
+intensity trend off: POD 0.588, FAR 0.237, CSI 0.497. Difference: 1 FA
+suppressed out of 55, 1 hit unaffected.
+
+Why no effect:
+- Of 55 Penrith FAs, only ~10 are truly approaching cells (positive predicted
+  arrival). The other 45 are overhead-transient FAs that intensity trend
+  doesn't address.
+- The 0.5 threshold (intensity must halve across the track) may be too strict
+  for the actual dissipation pattern. Cells in the radar tile may break apart
+  rather than fade in peak intensity.
+- The original 73% number may have come from a different baseline configuration.
+
+**Status**: kept as opt-in (`use_intensity_trend=False` default,
+`--use-intensity-trend` to enable in backtest). Tunable threshold could be
+explored. Currently does not provide a path to reducing Penrith FAs.
+
+**Next direction**: overhead transient FAs need a different approach -
+satellite cloud check, forecast PoP, or smarter clutter detection.
+
 ## Framework Improvements Done
 
 - [x] Compare feature (`--compare`)
@@ -165,6 +192,10 @@ Full results in reports/full-v1-aligned/.
 - [x] Tile decode optimisation (15ms → 1.2ms)
 - [x] Centroid extraction optimisation (12.5s → 25ms)
 - [x] Frame caching in replay and verifier
+- [x] Tier 0 diagnostic trace (`--inspect LOCATION TIMESTAMP`)
+- [x] Tier 1 multi-window inspect (`--inspect-set MANIFEST`)
+- [x] `--use-intensity-trend` flag (Phase 6A, neutral effect)
+- [x] `--frame-scale-by-lookahead` flag (Phase 3B, unvalidated)
 
 ## Framework Improvements Remaining
 

--- a/scripts/backtest/cli.py
+++ b/scripts/backtest/cli.py
@@ -181,6 +181,12 @@ def main(argv: list[str] | None = None) -> None:
         default=None,
         help="Run detect() on a single window and print the diagnostic trace as JSON. Args: location_name, window_end_ts",
     )
+    parser.add_argument(
+        "--inspect-set",
+        type=Path,
+        default=None,
+        help="Run --inspect on each window in a manifest file. Outputs a JSON list of traces.",
+    )
 
     args = parser.parse_args(argv)
 
@@ -194,6 +200,48 @@ def main(argv: list[str] | None = None) -> None:
         save_manifest(entries, "quick", "Auto-generated curated subset",
                       str(args.generate_subset), output_path)
         print(f"Generated manifest with {len(entries)} windows at {output_path}")
+        return
+
+    # Handle --inspect-set mode
+    if args.inspect_set is not None:
+        from scripts.backtest.manifest import load_manifest
+
+        manifest = load_manifest(args.inspect_set)
+
+        # Group entries by location (preserve manifest order)
+        entries_by_location: dict[str, list] = {}
+        for entry in manifest.entries:
+            entries_by_location.setdefault(entry.location, []).append(entry)
+
+        replay_kwargs = dict(
+            window_size=args.window_size,
+            max_gap_seconds=args.max_gap_seconds,
+            qc_enabled=(args.qc == "full"),
+            lookahead_seconds=args.lookahead_minutes * 60,
+        )
+        if args.intensity_threshold is not None:
+            replay_kwargs["intensity_threshold"] = args.intensity_threshold
+        if args.min_cell_area is not None:
+            replay_kwargs["min_cell_area_pixels"] = args.min_cell_area
+        if args.use_acceleration:
+            replay_kwargs["use_acceleration"] = True
+        if args.use_intensity_trend:
+            replay_kwargs["use_intensity_trend"] = True
+        config = ReplayConfig(**replay_kwargs)
+        engine = ReplayEngine(config)
+
+        captures_dir = args.data_dir / "captures"
+        traces_list: list[dict] = []
+        for location_name, loc_entries in entries_by_location.items():
+            loc_dir = captures_dir / location_name
+            captures = load_captures(loc_dir)
+            for entry in loc_entries:
+                _prediction, trace = engine.inspect_window(
+                    captures, window_end_ts=entry.window_end_ts
+                )
+                traces_list.append(dataclasses.asdict(trace))
+
+        print(json.dumps(traces_list, indent=2, default=str))
         return
 
     if args.data_dir is None:

--- a/scripts/backtest/cli.py
+++ b/scripts/backtest/cli.py
@@ -175,6 +175,12 @@ def main(argv: list[str] | None = None) -> None:
         help="Suppress detection of cells whose intensity is sharply declining (experimental)",
     )
     parser.add_argument(
+        "--frame-scale-by-lookahead",
+        action="store_true",
+        default=False,
+        help="Scale min_temporal_frames by lookahead (2 frames at <=20min, 3 at <=40min, 4 at >40min)",
+    )
+    parser.add_argument(
         "--inspect",
         nargs=2,
         metavar=("LOCATION", "TIMESTAMP"),
@@ -227,6 +233,8 @@ def main(argv: list[str] | None = None) -> None:
             replay_kwargs["use_acceleration"] = True
         if args.use_intensity_trend:
             replay_kwargs["use_intensity_trend"] = True
+        if args.frame_scale_by_lookahead:
+            replay_kwargs["frame_scale_by_lookahead"] = True
         config = ReplayConfig(**replay_kwargs)
         engine = ReplayEngine(config)
 
@@ -271,6 +279,10 @@ def main(argv: list[str] | None = None) -> None:
             replay_kwargs["min_cell_area_pixels"] = args.min_cell_area
         if args.use_acceleration:
             replay_kwargs["use_acceleration"] = True
+        if args.use_intensity_trend:
+            replay_kwargs["use_intensity_trend"] = True
+        if args.frame_scale_by_lookahead:
+            replay_kwargs["frame_scale_by_lookahead"] = True
         config = ReplayConfig(**replay_kwargs)
         engine = ReplayEngine(config)
         _prediction, trace = engine.inspect_window(captures, window_end_ts=window_end_ts)
@@ -301,6 +313,8 @@ def main(argv: list[str] | None = None) -> None:
         replay_kwargs["use_acceleration"] = True
     if args.use_intensity_trend:
         replay_kwargs["use_intensity_trend"] = True
+    if args.frame_scale_by_lookahead:
+        replay_kwargs["frame_scale_by_lookahead"] = True
     config = ReplayConfig(**replay_kwargs)
     engine = ReplayEngine(config)
     all_scorecards: list[ScoreCard] = []

--- a/scripts/backtest/cli.py
+++ b/scripts/backtest/cli.py
@@ -169,6 +169,12 @@ def main(argv: list[str] | None = None) -> None:
         help="Enable acceleration-aware cell projection (experimental)",
     )
     parser.add_argument(
+        "--use-intensity-trend",
+        action="store_true",
+        default=False,
+        help="Suppress detection of cells whose intensity is sharply declining (experimental)",
+    )
+    parser.add_argument(
         "--inspect",
         nargs=2,
         metavar=("LOCATION", "TIMESTAMP"),
@@ -245,6 +251,8 @@ def main(argv: list[str] | None = None) -> None:
         replay_kwargs["min_cell_area_pixels"] = args.min_cell_area
     if args.use_acceleration:
         replay_kwargs["use_acceleration"] = True
+    if args.use_intensity_trend:
+        replay_kwargs["use_intensity_trend"] = True
     config = ReplayConfig(**replay_kwargs)
     engine = ReplayEngine(config)
     all_scorecards: list[ScoreCard] = []

--- a/scripts/backtest/replay.py
+++ b/scripts/backtest/replay.py
@@ -75,6 +75,7 @@ class ReplayConfig:
     intensity_threshold: float = INTENSITY_THRESHOLD
     min_cell_area_pixels: int = MIN_CELL_AREA_PIXELS
     use_acceleration: bool = False
+    use_intensity_trend: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +115,7 @@ def _build_detector_config(
         grid_width=grid_size,
         grid_height=grid_size,
         use_acceleration=replay_config.use_acceleration,
+        use_intensity_trend=replay_config.use_intensity_trend,
     )
 
 

--- a/scripts/backtest/replay.py
+++ b/scripts/backtest/replay.py
@@ -76,6 +76,7 @@ class ReplayConfig:
     min_cell_area_pixels: int = MIN_CELL_AREA_PIXELS
     use_acceleration: bool = False
     use_intensity_trend: bool = False
+    frame_scale_by_lookahead: bool = False
 
 
 # ---------------------------------------------------------------------------
@@ -116,6 +117,7 @@ def _build_detector_config(
         grid_height=grid_size,
         use_acceleration=replay_config.use_acceleration,
         use_intensity_trend=replay_config.use_intensity_trend,
+        frame_scale_by_lookahead=replay_config.frame_scale_by_lookahead,
     )
 
 

--- a/tests/unit/backtest/test_cli.py
+++ b/tests/unit/backtest/test_cli.py
@@ -739,6 +739,37 @@ class TestIntensityThresholdFlag:
 
 
 # ---------------------------------------------------------------------------
+# Test: --use-intensity-trend flag
+# ---------------------------------------------------------------------------
+
+
+class TestMainUseIntensityTrend:
+    def test_use_intensity_trend_flag_passed_to_replay_config(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """--use-intensity-trend sets use_intensity_trend=True in ReplayConfig."""
+        from scripts.backtest.cli import main
+
+        data_dir = tmp_path / "data"
+        captures_dir = data_dir / "captures"
+        _make_location_dir(captures_dir, "loc1")
+
+        predictions = [_make_prediction()]
+
+        with patch("scripts.backtest.cli.ReplayEngine") as MockEngine, \
+             patch("scripts.backtest.cli.ReplayConfig") as MockConfig:
+            MockConfig.return_value = MagicMock()
+            instance = MockEngine.return_value
+            instance.replay.return_value = predictions
+
+            main(["--data-dir", str(data_dir), "--use-intensity-trend"])
+
+        MockConfig.assert_called_once()
+        _, kwargs = MockConfig.call_args
+        assert kwargs.get("use_intensity_trend") is True
+
+
+# ---------------------------------------------------------------------------
 # Test: --inspect <location> <timestamp> prints diagnostic trace as JSON
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/backtest/test_cli.py
+++ b/tests/unit/backtest/test_cli.py
@@ -770,6 +770,86 @@ class TestMainUseIntensityTrend:
 
 
 # ---------------------------------------------------------------------------
+# Test: --inspect-set loads manifest and runs inspect_window for each entry
+# ---------------------------------------------------------------------------
+
+
+class TestMainInspectSetMode:
+    def test_main_inspect_set_runs_inspect_window_for_each_manifest_entry(
+        self, tmp_path, capsys
+    ):
+        """When --inspect-set MANIFEST.json is called, ReplayEngine.inspect_window is called for each manifest entry."""
+        from scripts.backtest.cli import main
+        from custom_components.rain_incoming.radar.detector import (
+            DiagnosticTrace,
+            FrameDiagnostic,
+            DecisionDiagnostic,
+        )
+
+        data_dir = tmp_path / "data"
+        captures_dir = data_dir / "captures"
+        _make_location_dir(captures_dir, "loc1")
+
+        # Build a manifest with 2 entries
+        manifest_path = tmp_path / "manifest.json"
+        manifest_data = {
+            "name": "test",
+            "description": "test",
+            "created_from": "test",
+            "created_at": "2026-04-26T00:00:00Z",
+            "windows": [
+                {
+                    "location": "loc1",
+                    "window_end_ts": 1776700000,
+                    "category": "false_alarm",
+                    "subcategory": "dissipated",
+                },
+                {
+                    "location": "loc1",
+                    "window_end_ts": 1776700600,
+                    "category": "hit",
+                    "subcategory": "strong",
+                },
+            ],
+        }
+        manifest_path.write_text(json.dumps(manifest_data))
+
+        prediction = _make_prediction(rain_incoming=True, arrival_minutes=15.0)
+        trace = DiagnosticTrace(
+            frames=[FrameDiagnostic(cell_count=1)],
+            decision=DecisionDiagnostic(
+                rain_incoming=True, arrival_minutes=15.0, rain_at_location=False
+            ),
+        )
+
+        with patch("scripts.backtest.cli.ReplayEngine") as MockEngine:
+            instance = MockEngine.return_value
+            instance.inspect_window.return_value = (prediction, trace)
+
+            main([
+                "--data-dir", str(data_dir),
+                "--inspect-set", str(manifest_path),
+            ])
+
+        # inspect_window called once per manifest entry
+        assert instance.inspect_window.call_count == 2
+
+        # Output should be a JSON list with 2 entries
+        captured = capsys.readouterr()
+        out = captured.out
+        start = out.find("[")
+        end = out.rfind("]")
+        assert start >= 0 and end > start, f"No JSON array found in output:\n{out}"
+        parsed = json.loads(out[start:end+1])
+        assert isinstance(parsed, list)
+        assert len(parsed) == 2
+        # Each entry should be a trace dict
+        for entry in parsed:
+            assert "frames" in entry
+            assert "decision" in entry
+
+
+# ---------------------------------------------------------------------------
 # Test: --inspect <location> <timestamp> prints diagnostic trace as JSON
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/radar/test_detector.py
+++ b/tests/unit/radar/test_detector.py
@@ -818,6 +818,41 @@ class TestDetectDiagnostics:
         # Verify rain_at_location mirrors the result
         assert trace.decision.rain_at_location == result.rain_at_location
 
+    def test_diagnostics_records_velocity_and_intensity_for_accepted_track(self):
+        """When detect() runs on an approaching cell with constant intensity 0.8,
+        the trace's accepted track records velocity_kmh > 0, initial_intensity and
+        final_intensity both close to 0.8.
+        """
+        from custom_components.rain_incoming.radar.detector import (
+            DiagnosticTrace,
+        )
+
+        cfg = default_config()
+        # Build 3 frames where a cell at row 30-32 moves east 4px/frame with constant intensity 0.8
+        frames = []
+        for i, col_offset in enumerate([18, 22, 26]):
+            grid = np.zeros((64, 64), dtype=np.float32)
+            grid[30:33, col_offset : col_offset + 3] = 0.8
+            frames.append(make_frame(ts(-20 + i * 10), grid, cfg.analysis_bounds))
+
+        trace = DiagnosticTrace()
+        detect(frames=frames, location=(LAT, LON), config=cfg, diagnostics=trace)
+
+        # Find the accepted track (there should be one)
+        accepted_tracks = [t for t in trace.tracks if t.status == "accepted"]
+        assert len(accepted_tracks) == 1
+        track = accepted_tracks[0]
+
+        # Velocity should be > 0 (cell is moving)
+        assert track.velocity_kmh is not None
+        assert track.velocity_kmh > 0
+
+        # Intensity should be ~0.8 at both ends (constant intensity)
+        assert track.initial_intensity is not None
+        assert track.final_intensity is not None
+        assert track.initial_intensity == pytest.approx(0.8, abs=0.01)
+        assert track.final_intensity == pytest.approx(0.8, abs=0.01)
+
 
 class TestDetectIntensityTrend:
     def test_declining_intensity_suppresses_approaching_detection_when_enabled(self):

--- a/tests/unit/radar/test_detector.py
+++ b/tests/unit/radar/test_detector.py
@@ -817,3 +817,38 @@ class TestDetectDiagnostics:
 
         # Verify rain_at_location mirrors the result
         assert trace.decision.rain_at_location == result.rain_at_location
+
+
+class TestDetectIntensityTrend:
+    def test_declining_intensity_suppresses_approaching_detection_when_enabled(self):
+        """
+        When use_intensity_trend=True, a cell whose intensity sharply declines
+        (final < 0.5 * initial) should NOT trigger rain_incoming.
+        The same cell with use_intensity_trend=False (default) SHOULD trigger detection.
+        This proves the feature is what controls the behavior, not the fixture.
+        """
+        from dataclasses import replace
+
+        cfg_base = default_config()
+
+        # Cell approaches from west at row 30-32 (near location at row 32),
+        # moves east 4 pixels/frame (matches TestDetectRainApproaching pattern)
+        # with sharply declining intensity (19% of initial)
+        intensities = [0.8, 0.4, 0.15]  # final = 15/80 = 19% of initial
+        cols = [18, 22, 26]
+
+        frames = []
+        for i, (col, intensity) in enumerate(zip(cols, intensities)):
+            grid = np.zeros((64, 64), dtype=np.float32)
+            grid[30:33, col : col + 3] = intensity
+            frames.append(make_frame(ts(-20 + i * 10), grid, cfg_base.analysis_bounds))
+
+        # TREATMENT: use_intensity_trend=True should suppress the detection
+        cfg_with_trend = replace(cfg_base, use_intensity_trend=True)
+        result = detect(frames, (LAT, LON), cfg_with_trend)
+        assert result.rain_incoming is False, "Declining cell should be suppressed when use_intensity_trend=True"
+
+        # CONTROL: use_intensity_trend=False (default) should allow detection
+        cfg_default = default_config()  # use_intensity_trend=False
+        result_control = detect(frames, (LAT, LON), cfg_default)
+        assert result_control.rain_incoming is True, "Same cell should be detected when use_intensity_trend=False"

--- a/tests/unit/radar/test_detector.py
+++ b/tests/unit/radar/test_detector.py
@@ -852,3 +852,45 @@ class TestDetectIntensityTrend:
         cfg_default = default_config()  # use_intensity_trend=False
         result_control = detect(frames, (LAT, LON), cfg_default)
         assert result_control.rain_incoming is True, "Same cell should be detected when use_intensity_trend=False"
+
+
+class TestDetectFrameScaling:
+    def test_frame_scale_by_lookahead_drops_short_tracks_at_long_lookahead(self):
+        """
+        When frame_scale_by_lookahead=True is set and lookahead is 30+ minutes,
+        a 2-frame track is dropped even though min_temporal_frames=2 would normally
+        accept it. The same 2-frame track is accepted when the flag is off (control).
+        """
+        from dataclasses import replace
+
+        # Build 3 frames where a cell appears only in the last 2 frames
+        # (creating a 2-frame track ending on the last frame).
+        grids = [
+            np.zeros((64, 64), dtype=np.float32),  # frame 0: empty
+            np.zeros((64, 64), dtype=np.float32),  # frame 1: cell starts
+            np.zeros((64, 64), dtype=np.float32),  # frame 2: cell moves east (near location)
+        ]
+        grids[1][30:33, 24:27] = 0.8  # cell starts here
+        grids[2][30:33, 28:31] = 0.8  # 4px east, centroid near location
+
+        frames = [
+            make_frame(ts(-20 + i * 10), grids[i], default_config().analysis_bounds)
+            for i in range(3)
+        ]
+
+        cfg_default = default_config()  # frame_scale_by_lookahead=False, lookahead=60min
+
+        # CONTROL: without flag, the 2-frame track IS valid (len >= min_temporal_frames=2)
+        # and should trigger detection
+        result_default = detect(frames, (LAT, LON), cfg_default)
+        assert (
+            result_default.rain_incoming is True
+        ), "Without frame scaling, 2-frame track should be detected"
+
+        # TREATMENT: with flag enabled at default 60min lookahead,
+        # effective min = max(2, 4) = 4. 2-frame track is dropped, no detection.
+        cfg_scaled = replace(cfg_default, frame_scale_by_lookahead=True)
+        result_scaled = detect(frames, (LAT, LON), cfg_scaled)
+        assert (
+            result_scaled.rain_incoming is False
+        ), "With frame scaling at 60min lookahead, 2-frame track should be dropped"


### PR DESCRIPTION
**Stacked on PR #159 (Tier 0).** Will rebase clean onto main after #159 merges.

## Summary

Three additions on top of Tier 0:

### Tier 1: `--inspect-set MANIFEST` (multi-window inspect)
Reuses the existing manifest format. Runs `inspect_window` for each window in the manifest, outputs a JSON list of traces (one per entry). Enables fast iteration on a curated set of problem windows.

Workflow: edit a model variant → run `--inspect-set problems.json` → see how each window's trace changed → validate with `--subset` → validate with full backtest.

### Phase 6A: Intensity trend filter (NEUTRAL, kept opt-in)
**Hypothesis was wrong**: 73% of Penrith FAs were claimed to be dissipating cells. Filter suppresses approaching cells whose final-frame intensity is < 0.5 of initial. Empirical result on Penrith at 30min lookahead: **1 FA suppressed out of 55, no measurable POD/FAR/CSI change**.

Root cause: ~45 of 55 Penrith FAs are overhead transients (negative predicted arrival), not approaching cells. Intensity trend only applies to approaching tracks.

**Kept as opt-in** (`--use-intensity-trend`) for further tuning. Path to reducing Penrith FAs needs confidence signals (forecast/satellite) instead.

### Phase 3B: Frame-scaled min_temporal_frames (UNVALIDATED)
Opt-in via `--frame-scale-by-lookahead`. Scales required track length:
- ≤20min lookahead: 2 frames
- 20-40min: 3 frames
- 40-60min: 4 frames

Test confirms behavior. Backtest validation pending.

## Test plan

- [x] 528 unit tests pass, 110 integration tests pass
- [x] Empirical: Penrith intensity-trend on/off comparison at 30min lookahead
- [ ] CI passes
- [ ] After #159 merges: rebase onto main

🤖 Generated with [Claude Code](https://claude.com/claude-code)