### PR TITLE
Phase 5B: Satellite IR cloud-presence confidence signal

### DIFF
--- a/custom_components/rain_incoming/config_flow.py
+++ b/custom_components/rain_incoming/config_flow.py
@@ -18,6 +18,7 @@ from .const import (
     CONF_LOCATION_NAME,
     CONF_LOOKAHEAD_MINUTES,
     CONF_MAP_STYLE,
+    CONF_SATELLITE_CONFIDENCE_ENABLED,
     DEFAULT_LOOKAHEAD_MINUTES,
     DOMAIN,
     MAX_LOCATION_NAME_CHARS,
@@ -130,6 +131,7 @@ def _build_options_schema(
     default_location_name: str = "",
     default_map_style: str = _DEFAULT_MAP_STYLE,
     default_forecast_confidence: bool = False,
+    default_satellite_confidence: bool = False,
 ) -> vol.Schema:
     return vol.Schema(
         {
@@ -145,6 +147,7 @@ def _build_options_schema(
                 )
             ),
             vol.Optional(CONF_FORECAST_CONFIDENCE_ENABLED, default=default_forecast_confidence): bool,
+            vol.Optional(CONF_SATELLITE_CONFIDENCE_ENABLED, default=default_satellite_confidence): bool,
         }
     )
 
@@ -248,6 +251,7 @@ def _merge_options_into_data(existing_data: dict, user_input: dict) -> dict:
         CONF_LOOKAHEAD_MINUTES,
         CONF_MAP_STYLE,
         CONF_FORECAST_CONFIDENCE_ENABLED,
+        CONF_SATELLITE_CONFIDENCE_ENABLED,
     )
     merged = dict(existing_data)
     for key in _EDITABLE_OPTION_KEYS:
@@ -273,6 +277,7 @@ def _resolve_options_schema_defaults(
             default_location_name=user_input.get(CONF_LOCATION_NAME, ""),
             default_map_style=user_input.get(CONF_MAP_STYLE, _DEFAULT_MAP_STYLE),
             default_forecast_confidence=user_input.get(CONF_FORECAST_CONFIDENCE_ENABLED, current_data.get(CONF_FORECAST_CONFIDENCE_ENABLED, False)),
+            default_satellite_confidence=user_input.get(CONF_SATELLITE_CONFIDENCE_ENABLED, current_data.get(CONF_SATELLITE_CONFIDENCE_ENABLED, False)),
         )
     # First render: use persisted values from entry.data.
     return _build_options_schema(
@@ -282,6 +287,7 @@ def _resolve_options_schema_defaults(
         default_location_name=current_data.get(CONF_LOCATION_NAME, ""),
         default_map_style=current_data.get(CONF_MAP_STYLE, _DEFAULT_MAP_STYLE),
         default_forecast_confidence=current_data.get(CONF_FORECAST_CONFIDENCE_ENABLED, False),
+        default_satellite_confidence=current_data.get(CONF_SATELLITE_CONFIDENCE_ENABLED, False),
     )
 
 

--- a/custom_components/rain_incoming/const.py
+++ b/custom_components/rain_incoming/const.py
@@ -5,6 +5,7 @@ CONF_LOCATION_NAME = "location_name"
 CONF_LOOKAHEAD_MINUTES = "lookahead_minutes"
 CONF_MAP_STYLE = "map_style"
 CONF_FORECAST_CONFIDENCE_ENABLED = "forecast_confidence_enabled"
+CONF_SATELLITE_CONFIDENCE_ENABLED = "satellite_confidence_enabled"
 
 # Bypass criteria for the PoP multiplier gate. Both must be met:
 # - intensity at or above STRONG_BYPASS_INTENSITY (well above the 0.1 noise floor)
@@ -64,3 +65,26 @@ RAINVIEWER_ANALYSIS_GRID = 2  # fetch (2*N+1)^2 tiles centred on location
 # as a source of the data on your website with a link: https://www.rainviewer.com/"
 # We can't render hyperlinks in a baked GIF, so we include the domain in the text.
 RAINVIEWER_ATTRIBUTION = "rainviewer.com"
+
+# NASA GIBS Himawari Band 13 Clean Infrared - cloud presence at zoom 6 (max).
+# Used as a confidence signal: no clouds nearby means radar returns are noise.
+GIBS_HIMAWARI_URL = (
+    "https://gibs.earthdata.nasa.gov/wmts/epsg3857/best/"
+    "Himawari_AHI_Band13_Clean_Infrared/default/default/"
+    "GoogleMapsCompatible_Level6/{z}/{y}/{x}.png"
+)
+GIBS_HIMAWARI_ZOOM = 6
+
+# Satellite IR cloud-presence detection parameters (POC-validated).
+# Pixels with luminance >= threshold are treated as cloudy. Threshold ~120
+# matches the colormap rendering for cold-cloud tops in Band 13. The 50km
+# window around a location is wide enough to capture nearby clouds that
+# could plausibly produce radar returns at the location itself.
+SATELLITE_CHECK_RADIUS_KM = 50
+SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD = 120
+
+# A cloud-presence fraction at or above this value within the check window
+# means clouds are present and radar returns can be trusted normally. Below
+# this, the sky is treated as clear and any radar return is presumed noise -
+# the detection threshold is raised to compensate.
+SATELLITE_CLOUD_PRESENCE_FRACTION = 0.1

--- a/custom_components/rain_incoming/coordinator.py
+++ b/custom_components/rain_incoming/coordinator.py
@@ -41,6 +41,7 @@ from .const import (
     CONF_FORECAST_CONFIDENCE_ENABLED,
     CONF_LOOKAHEAD_MINUTES,
     CONF_MAP_STYLE,
+    CONF_SATELLITE_CONFIDENCE_ENABLED,
     DEFAULT_LOOKAHEAD_MINUTES,
     INTENSITY_THRESHOLD,
     MAX_ANGULAR_VARIANCE_RADIANS,
@@ -51,12 +52,15 @@ from .const import (
     PROXIMITY_RADIUS_KM,
     RAINVIEWER_ZOOM,
     RAINVIEWER_TILE_SIZE,
+    SATELLITE_CHECK_RADIUS_KM,
+    SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD,
 )
 from .http_retry import RateLimitBudget
 from .providers.base import BoundingBox
+from .providers.himawari import cloud_fraction_in_window, fetch_himawari_ir_tile
 from .providers.open_meteo import fetch_hourly_pop, max_pop_in_window
 from .providers.rainviewer import RainViewerProvider
-from .radar.confidence import pop_to_threshold_multiplier
+from .radar.confidence import cloud_to_threshold_multiplier, pop_to_threshold_multiplier
 from .radar.detector import Confidence, DetectionResult, DetectorConfig, TrackedCell, detect
 from .radar.qc import (
     ClutterMap,
@@ -191,6 +195,22 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
         window_max = max_pop_in_window(forecast, now, now + timedelta(hours=1))
         return pop_to_threshold_multiplier(window_max)
 
+    async def _compute_satellite_multiplier(
+        self, lat: float, lon: float, session: aiohttp.ClientSession
+    ) -> float:
+        """Compute satellite confidence threshold multiplier from cloud presence."""
+        if not self._entry.data.get(CONF_SATELLITE_CONFIDENCE_ENABLED, False):
+            return 1.0
+        tile = await fetch_himawari_ir_tile(lat, lon, session)
+        if tile is None:
+            return 1.0
+        fraction = cloud_fraction_in_window(
+            tile, lat, lon,
+            SATELLITE_CHECK_RADIUS_KM,
+            SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD,
+        )
+        return cloud_to_threshold_multiplier(fraction)
+
     def _build_config(self, pop_multiplier: float = 1.0) -> DetectorConfig:
         data = self._entry.data
         lat = data.get(CONF_LATITUDE, self.hass.config.latitude)
@@ -225,8 +245,9 @@ class RainDetectorCoordinator(DataUpdateCoordinator[DetectionResult]):
         except Exception as err:
             raise UpdateFailed(f"RainViewer fetch failed: {err}") from err
 
-        multiplier = await self._compute_pop_multiplier(lat, lon, session)
-        config = self._build_config(pop_multiplier=multiplier)
+        pop_mult = await self._compute_pop_multiplier(lat, lon, session)
+        sat_mult = await self._compute_satellite_multiplier(lat, lon, session)
+        config = self._build_config(pop_multiplier=max(pop_mult, sat_mult))
 
         await self._ensure_clutter_map_loaded()
         frames = await self._resolve_frame_cache(frames, config, session)

--- a/custom_components/rain_incoming/providers/himawari.py
+++ b/custom_components/rain_incoming/providers/himawari.py
@@ -1,0 +1,92 @@
+"""NASA GIBS Himawari Band 13 Clean Infrared tile provider.
+
+Used as a cloud-presence confidence signal: if there are no clouds near a
+location, any radar return is noise. Tiles are 256x256 RGBA PNG at zoom 6
+(the max available for this layer).
+"""
+from __future__ import annotations
+
+import logging
+import math
+from dataclasses import dataclass
+from io import BytesIO
+
+import aiohttp
+import numpy as np
+from PIL import Image
+
+from ..const import GIBS_HIMAWARI_URL, GIBS_HIMAWARI_ZOOM
+from ..http_retry import fetch_with_retry
+
+_LOGGER = logging.getLogger(__name__)
+
+
+@dataclass
+class IRTile:
+    pixels: np.ndarray  # (256, 256, 4) RGBA uint8
+    tile_x: int
+    tile_y: int
+    zoom: int
+
+
+def _lat_lon_to_tile(lat: float, lon: float, zoom: int) -> tuple[int, int]:
+    n = 2 ** zoom
+    x = int((lon + 180.0) / 360.0 * n)
+    y = int((1.0 - math.asinh(math.tan(math.radians(lat))) / math.pi) / 2.0 * n)
+    return x, y
+
+
+def cloud_fraction_in_window(
+    tile: IRTile,
+    lat: float,
+    lon: float,
+    radius_km: float,
+    threshold: int,
+) -> float:
+    """Fraction of pixels within radius_km of (lat, lon) whose luminance >= threshold.
+
+    Luminance is the mean of the RGB channels. Window bounds are clamped to
+    the 256x256 tile, so radii larger than the tile span are safe.
+    """
+    n = 2 ** tile.zoom
+    fx = (lon + 180.0) / 360.0 * n
+    lat_rad = math.radians(lat)
+    fy = (1.0 - math.asinh(math.tan(lat_rad)) / math.pi) / 2.0 * n
+    px = int((fx - tile.tile_x) * 256)
+    py = int((fy - tile.tile_y) * 256)
+
+    km_per_px = (40075.0 * math.cos(lat_rad)) / (n * 256)
+    half = max(1, int(radius_km / km_per_px))
+
+    x0 = max(0, px - half)
+    x1 = min(256, px + half + 1)
+    y0 = max(0, py - half)
+    y1 = min(256, py + half + 1)
+
+    window = tile.pixels[y0:y1, x0:x1]
+    luminance = window[:, :, :3].astype(np.float32).mean(axis=2)
+    return float((luminance >= threshold).mean())
+
+
+async def fetch_himawari_ir_tile(
+    lat: float, lon: float, session: aiohttp.ClientSession
+) -> IRTile | None:
+    zoom = GIBS_HIMAWARI_ZOOM
+    x, y = _lat_lon_to_tile(lat, lon, zoom)
+    url = GIBS_HIMAWARI_URL.format(z=zoom, y=y, x=x)
+    try:
+        resp = await fetch_with_retry(session, url)
+        data = await resp.read()
+        img = Image.open(BytesIO(data)).convert("RGBA")
+        pixels = np.array(img, dtype=np.uint8)
+        return IRTile(pixels=pixels, tile_x=x, tile_y=y, zoom=zoom)
+    except aiohttp.ClientResponseError as e:
+        _LOGGER.warning(
+            "Himawari IR tile fetch failed: HTTP %d for %s", e.status, url
+        )
+        return None
+    except Exception as e:
+        _LOGGER.warning(
+            "Himawari IR tile decode failed: %s: %s", type(e).__name__, e
+        )
+        return None

--- a/custom_components/rain_incoming/radar/confidence.py
+++ b/custom_components/rain_incoming/radar/confidence.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from ..const import SATELLITE_CLOUD_PRESENCE_FRACTION
+
 
 def pop_to_threshold_multiplier(pop_pct: float | None) -> float:
     """Map forecast PoP percentage to confidence threshold multiplier.
@@ -13,4 +15,18 @@ def pop_to_threshold_multiplier(pop_pct: float | None) -> float:
         return 3.0
     if pop_pct < 30:
         return 2.0
+    return 1.0
+
+
+def cloud_to_threshold_multiplier(cloud_fraction: float | None) -> float:
+    """Map satellite cloud fraction to confidence threshold multiplier.
+
+    None (satellite unavailable) returns 1.0 (fail open).
+    Clear sky (fraction below the cloud-presence threshold) raises the bar
+    to 3.0 - any radar return there is likely noise.
+    """
+    if cloud_fraction is None:
+        return 1.0
+    if cloud_fraction < SATELLITE_CLOUD_PRESENCE_FRACTION:
+        return 3.0
     return 1.0

--- a/tests/e2e/test_sensors_e2e.py
+++ b/tests/e2e/test_sensors_e2e.py
@@ -42,9 +42,10 @@ class TestIntegratedRainValidation:
     def _download_gif(self, ha_client, scenario, entity_id=IMAGE_128, previous_gif=None):
         """Set scenario, wait for coordinator cycle, then download GIF.
 
-        If previous_gif is provided, polls until the image differs from it
-        (handles async_image returning stale cached data). Otherwise polls
-        until the image has non-trivial content.
+        If previous_gif is provided, polls until the image differs VISUALLY from
+        it (handles both stale cached data and re-renders with new timestamps but
+        identical tile content). Otherwise polls until the image has non-trivial
+        content.
 
         Raises AssertionError on timeout so the failure message is diagnostic
         ("timed out waiting for render") rather than misleading ("images identical").
@@ -55,16 +56,22 @@ class TestIntegratedRainValidation:
         while time.time() < deadline:
             gif = ha_client.get_image(entity_id)
             if gif and len(gif) > 1000:
-                if previous_gif is None or gif != previous_gif:
+                if previous_gif is None:
+                    return gif
+                differs, _ = images_differ_significantly(gif, previous_gif)
+                if differs:
                     return gif
             time.sleep(2)
         gif = ha_client.get_image(entity_id)
-        if previous_gif is not None and gif == previous_gif:
-            raise AssertionError(
-                f"Timed out after {_IMAGE_POLL_TIMEOUT}s waiting for '{scenario}' "
-                f"image to differ from previous scenario. "
-                f"Image render may not have completed in time."
-            )
+        if previous_gif is not None:
+            differs, fraction = images_differ_significantly(gif, previous_gif) if gif else (False, 0.0)
+            if not differs:
+                raise AssertionError(
+                    f"Timed out after {_IMAGE_POLL_TIMEOUT}s waiting for '{scenario}' "
+                    f"image to differ visually from previous scenario "
+                    f"(diff fraction: {fraction:.4f}). "
+                    f"Image render may not have completed in time."
+                )
         if not gif or len(gif) <= 1000:
             raise AssertionError(
                 f"Timed out after {_IMAGE_POLL_TIMEOUT}s waiting for '{scenario}' "

--- a/tests/integration/test_config_flow.py
+++ b/tests/integration/test_config_flow.py
@@ -13,6 +13,7 @@ from custom_components.rain_incoming.const import (
     CONF_FORECAST_CONFIDENCE_ENABLED,
     CONF_LOCATION_NAME,
     CONF_MAP_STYLE,
+    CONF_SATELLITE_CONFIDENCE_ENABLED,
     DOMAIN,
 )
 from .conftest import setup_integration
@@ -954,4 +955,38 @@ async def test_options_flow_persists_forecast_confidence_enabled(hass: HomeAssis
     assert result["type"] == FlowResultType.CREATE_ENTRY
     assert entry.data[CONF_FORECAST_CONFIDENCE_ENABLED] is True, (
         f"Expected CONF_FORECAST_CONFIDENCE_ENABLED=True in entry.data, got {entry.data.get(CONF_FORECAST_CONFIDENCE_ENABLED)!r}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_options_flow_satellite_confidence_toggle(hass: HomeAssistant):
+    """Submitting CONF_SATELLITE_CONFIDENCE_ENABLED=True via OptionsFlow persists it to entry.data."""
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "voyager",
+        },
+        version=2,
+    )
+    await setup_integration(hass, entry, _MOCK_RESULT)
+
+    result = await hass.config_entries.options.async_init(entry.entry_id)
+    assert result["type"] == FlowResultType.FORM
+
+    result = await hass.config_entries.options.async_configure(
+        result["flow_id"],
+        {
+            "latitude": -33.701,
+            "longitude": 151.209,
+            "lookahead_minutes": 60,
+            CONF_MAP_STYLE: "voyager",
+            CONF_SATELLITE_CONFIDENCE_ENABLED: True,
+        },
+    )
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert entry.data[CONF_SATELLITE_CONFIDENCE_ENABLED] is True, (
+        f"Expected CONF_SATELLITE_CONFIDENCE_ENABLED=True in entry.data, got {entry.data.get(CONF_SATELLITE_CONFIDENCE_ENABLED)!r}"
     )

--- a/tests/unit/providers/test_himawari.py
+++ b/tests/unit/providers/test_himawari.py
@@ -1,0 +1,226 @@
+from __future__ import annotations
+
+import logging
+from io import BytesIO
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import numpy as np
+import pytest
+from PIL import Image
+
+from custom_components.rain_incoming.const import (
+    SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD,
+)
+from custom_components.rain_incoming.providers.himawari import (
+    IRTile,
+    cloud_fraction_in_window,
+    fetch_himawari_ir_tile,
+)
+
+
+def _make_ir_tile_png() -> bytes:
+    """Create a minimal 256x256 RGBA PNG simulating a Himawari IR tile."""
+    img = Image.new("RGBA", (256, 256), (80, 80, 80, 255))
+    buf = BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+class TestFetchHimawariIrTile:
+    @pytest.mark.asyncio
+    async def test_returns_ir_tile_for_known_location(self):
+        """Happy path: fetch returns IRTile with correct shape, dtype, zoom,
+        and the GIBS Himawari layer URL is requested."""
+        tile_bytes = _make_ir_tile_png()
+
+        captured_urls: list[str] = []
+
+        async def _fake_fetch(session, url, **kwargs):
+            captured_urls.append(url)
+            resp = AsyncMock()
+            resp.read = AsyncMock(return_value=tile_bytes)
+            return resp
+
+        mock_session = MagicMock()
+
+        with patch(
+            "custom_components.rain_incoming.providers.himawari.fetch_with_retry",
+            side_effect=_fake_fetch,
+        ):
+            # Sydney
+            result = await fetch_himawari_ir_tile(-33.87, 151.21, mock_session)
+
+        assert result is not None
+        assert isinstance(result, IRTile)
+        assert isinstance(result.pixels, np.ndarray)
+        assert result.pixels.shape == (256, 256, 4)
+        assert result.pixels.dtype == np.uint8
+        assert isinstance(result.tile_x, int)
+        assert isinstance(result.tile_y, int)
+        assert result.zoom == 6
+
+        assert len(captured_urls) == 1
+        url = captured_urls[0]
+        assert "Himawari_AHI_Band13_Clean_Infrared" in url
+        assert "GoogleMapsCompatible_Level6" in url
+        assert "/6/" in url  # zoom 6
+
+    @pytest.mark.asyncio
+    async def test_returns_none_and_warns_on_http_error(self, caplog):
+        """Sad path: HTTP error from fetch_with_retry returns None and logs WARNING."""
+        http_error = aiohttp.ClientResponseError(
+            request_info=MagicMock(),
+            history=(),
+            status=404,
+            message="Not Found",
+        )
+
+        mock_session = MagicMock()
+        with caplog.at_level(logging.WARNING, logger="custom_components.rain_incoming.providers.himawari"):
+            with patch(
+                "custom_components.rain_incoming.providers.himawari.fetch_with_retry",
+                side_effect=http_error,
+            ):
+                result = await fetch_himawari_ir_tile(-33.87, 151.21, mock_session)
+
+        assert result is None
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "Expected at least one WARNING log on HTTP error"
+        combined = " ".join(r.getMessage() for r in warnings)
+        assert "404" in combined, f"WARNING should include HTTP status; got: {combined!r}"
+        assert "Himawari" in combined, f"WARNING should include layer/URL hint; got: {combined!r}"
+
+    @pytest.mark.asyncio
+    async def test_returns_none_and_warns_on_malformed_response(self, caplog):
+        """Sad path: non-PNG response body causes Image.open to raise; we
+        return None and log WARNING rather than letting it propagate."""
+        bad_resp = AsyncMock()
+        bad_resp.read = AsyncMock(return_value=b"not a png")
+
+        async def _fake_fetch(session, url, **kwargs):
+            return bad_resp
+
+        mock_session = MagicMock()
+        with caplog.at_level(logging.WARNING, logger="custom_components.rain_incoming.providers.himawari"):
+            with patch(
+                "custom_components.rain_incoming.providers.himawari.fetch_with_retry",
+                side_effect=_fake_fetch,
+            ):
+                result = await fetch_himawari_ir_tile(-33.87, 151.21, mock_session)
+
+        assert result is None
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert warnings, "Expected at least one WARNING log on malformed response"
+
+
+# Sydney coords -> tile (58, 38) at zoom 6 per _lat_lon_to_tile. Reused
+# across cloud-fraction tests so the (lat, lon) the function uses to locate
+# the window aligns with the synthetic tile we hand it.
+_SYDNEY_LAT = -33.87
+_SYDNEY_LON = 151.21
+_SYDNEY_TILE_X = 58
+_SYDNEY_TILE_Y = 38
+
+
+def _make_uniform_tile(rgb: tuple[int, int, int]) -> IRTile:
+    """Build a synthetic IRTile filled with a uniform RGB colour."""
+    pixels = np.zeros((256, 256, 4), dtype=np.uint8)
+    pixels[:, :, 0] = rgb[0]
+    pixels[:, :, 1] = rgb[1]
+    pixels[:, :, 2] = rgb[2]
+    pixels[:, :, 3] = 255
+    return IRTile(
+        pixels=pixels,
+        tile_x=_SYDNEY_TILE_X,
+        tile_y=_SYDNEY_TILE_Y,
+        zoom=6,
+    )
+
+
+class TestCloudFractionInWindow:
+    """`cloud_fraction_in_window` is a pure function over IRTile.pixels.
+
+    Luminance = mean of RGB channels. Pixels whose luminance is >= threshold
+    count as cloudy. Result is the cloudy fraction within a circular/square
+    window of `radius_km` around (lat, lon)."""
+
+    def test_all_bright_pixels_returns_one(self):
+        bright = SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD + 30
+        tile = _make_uniform_tile((bright, bright, bright))
+
+        result = cloud_fraction_in_window(
+            tile,
+            _SYDNEY_LAT,
+            _SYDNEY_LON,
+            radius_km=50,
+            threshold=SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD,
+        )
+
+        assert result == pytest.approx(1.0)
+
+    def test_all_dark_pixels_returns_zero(self):
+        dark = SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD - 30
+        tile = _make_uniform_tile((dark, dark, dark))
+
+        result = cloud_fraction_in_window(
+            tile,
+            _SYDNEY_LAT,
+            _SYDNEY_LON,
+            radius_km=50,
+            threshold=SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD,
+        )
+
+        assert result == pytest.approx(0.0)
+
+    def test_pixels_at_threshold_count_as_cloudy(self):
+        """Boundary case: luminance == threshold must be treated as cloudy
+        (>= comparison, not strict >). A tile uniformly filled at exactly
+        threshold should yield fraction = 1.0."""
+        thr = SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD
+        tile = _make_uniform_tile((thr, thr, thr))
+
+        result = cloud_fraction_in_window(
+            tile,
+            _SYDNEY_LAT,
+            _SYDNEY_LON,
+            radius_km=50,
+            threshold=thr,
+        )
+
+        assert result == pytest.approx(1.0)
+
+    def test_half_bright_half_dark_returns_about_half(self):
+        """Mixed tile: top half rows bright (cloudy), bottom half dark.
+
+        Use a large radius so the window covers the full tile, making the
+        cloudy fraction exactly 0.5 regardless of where Sydney lands within
+        the tile."""
+        bright = SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD + 30
+        dark = SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD - 30
+
+        pixels = np.zeros((256, 256, 4), dtype=np.uint8)
+        pixels[:128, :, 0:3] = bright
+        pixels[128:, :, 0:3] = dark
+        pixels[:, :, 3] = 255
+
+        tile = IRTile(
+            pixels=pixels,
+            tile_x=_SYDNEY_TILE_X,
+            tile_y=_SYDNEY_TILE_Y,
+            zoom=6,
+        )
+
+        # Radius huge enough that the window covers the full 256x256 tile.
+        # At zoom 6 / lat ~-34, km_per_pixel ~2.16km, so 256 px is ~553 km.
+        result = cloud_fraction_in_window(
+            tile,
+            _SYDNEY_LAT,
+            _SYDNEY_LON,
+            radius_km=10_000,
+            threshold=SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD,
+        )
+
+        assert result == pytest.approx(0.5, abs=0.01)

--- a/tests/unit/radar/test_confidence.py
+++ b/tests/unit/radar/test_confidence.py
@@ -2,7 +2,13 @@ from __future__ import annotations
 
 import pytest
 
-from custom_components.rain_incoming.radar.confidence import pop_to_threshold_multiplier
+from custom_components.rain_incoming.const import (
+    SATELLITE_CLOUD_PRESENCE_FRACTION,
+)
+from custom_components.rain_incoming.radar.confidence import (
+    cloud_to_threshold_multiplier,
+    pop_to_threshold_multiplier,
+)
 
 
 class TestPopToThresholdMultiplier:
@@ -21,3 +27,31 @@ class TestPopToThresholdMultiplier:
     def test_mapping(self, pop_pct, expected):
         """Boundary-correct mapping from PoP percentage to threshold multiplier."""
         assert pop_to_threshold_multiplier(pop_pct) == expected
+
+
+class TestCloudToThresholdMultiplier:
+    """Maps satellite cloud-fraction to a detection threshold multiplier.
+
+    Mirrors `pop_to_threshold_multiplier`'s asymmetric semantics: when the
+    satellite signal is missing (None), fail open (1.0). When the sky is
+    clear, raise the bar (3.0) - any radar return is likely noise. When
+    clouds are present, trust the radar normally (1.0).
+    """
+
+    @pytest.mark.parametrize(
+        "cloud_fraction, expected",
+        [
+            (None, 1.0),                                          # satellite unavailable: fail open
+            (0.0, 3.0),                                           # totally clear: raise bar
+            (SATELLITE_CLOUD_PRESENCE_FRACTION - 0.01, 3.0),      # just below threshold: still raise bar
+            (SATELLITE_CLOUD_PRESENCE_FRACTION, 1.0),             # at boundary: clouds present
+            (SATELLITE_CLOUD_PRESENCE_FRACTION + 0.01, 1.0),      # just above boundary: clouds present
+            (1.0, 1.0),                                           # totally cloudy: trust radar
+        ],
+    )
+    def test_mapping(self, cloud_fraction, expected):
+        """Boundary-correct mapping from cloud fraction to threshold multiplier.
+
+        Boundary case (== threshold) maps to 1.0 because the predicate is
+        "clouds present" (>=), not "more than threshold" (>)."""
+        assert cloud_to_threshold_multiplier(cloud_fraction) == expected

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -8,7 +8,11 @@ import numpy as np
 import pytest
 
 from custom_components.rain_incoming.coordinator import RainDetectorCoordinator
-from custom_components.rain_incoming.const import CONF_FORECAST_CONFIDENCE_ENABLED
+from custom_components.rain_incoming.const import (
+    CONF_FORECAST_CONFIDENCE_ENABLED,
+    CONF_SATELLITE_CONFIDENCE_ENABLED,
+)
+from custom_components.rain_incoming.providers.himawari import IRTile
 from custom_components.rain_incoming.providers.rainviewer import RainViewerFrame
 from custom_components.rain_incoming.radar.detector import Confidence, DetectionResult
 
@@ -82,6 +86,129 @@ class TestComputePopMultiplier:
 
         assert result == 1.0, f"Expected 1.0 when disabled, got {result}"
         mock_fetch.assert_not_called()
+
+
+class TestComputeSatelliteMultiplier:
+    @pytest.mark.asyncio
+    async def test_enabled_with_clear_sky_returns_3x_multiplier(self):
+        """Happy path: enabled=True + clear-sky tile → multiplier 3.0.
+
+        A dark IR tile (luminance below threshold everywhere) yields
+        cloud_fraction=0.0, which is below SATELLITE_CLOUD_PRESENCE_FRACTION,
+        so cloud_to_threshold_multiplier returns 3.0.
+        """
+        coordinator = _make_coordinator(extra_data={CONF_SATELLITE_CONFIDENCE_ENABLED: True})
+        mock_session = AsyncMock()
+
+        dark_tile = IRTile(
+            pixels=np.zeros((256, 256, 4), dtype=np.uint8),
+            tile_x=0,
+            tile_y=0,
+            zoom=6,
+        )
+
+        with (
+            patch(
+                "custom_components.rain_incoming.coordinator.fetch_himawari_ir_tile",
+                new=AsyncMock(return_value=dark_tile),
+            ),
+            patch(
+                "custom_components.rain_incoming.coordinator.cloud_fraction_in_window",
+                return_value=0.0,
+            ),
+        ):
+            result = await coordinator._compute_satellite_multiplier(-33.7, 151.2, mock_session)
+
+        assert result == 3.0, f"Expected multiplier 3.0 for clear sky (cloud_fraction=0.0), got {result}"
+
+    @pytest.mark.asyncio
+    async def test_disabled_returns_1_without_fetching(self):
+        """When CONF_SATELLITE_CONFIDENCE_ENABLED is False, return 1.0 and skip fetch."""
+        coordinator = _make_coordinator(extra_data={CONF_SATELLITE_CONFIDENCE_ENABLED: False})
+        mock_session = AsyncMock()
+
+        with patch(
+            "custom_components.rain_incoming.coordinator.fetch_himawari_ir_tile",
+            new=AsyncMock(),
+        ) as mock_fetch:
+            result = await coordinator._compute_satellite_multiplier(-33.7, 151.2, mock_session)
+
+        assert result == 1.0, f"Expected 1.0 when disabled, got {result}"
+        mock_fetch.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_tile_fetch_failure_returns_1_without_crash(self):
+        """Enabled but tile fetch returns None → fail open with multiplier 1.0, no exception.
+
+        `cloud_fraction_in_window` must NOT be called when tile is None - calling
+        it on None would crash. Verify both the return value and that the
+        guard short-circuits the cloud-fraction computation.
+        """
+        coordinator = _make_coordinator(extra_data={CONF_SATELLITE_CONFIDENCE_ENABLED: True})
+        mock_session = AsyncMock()
+
+        with (
+            patch(
+                "custom_components.rain_incoming.coordinator.fetch_himawari_ir_tile",
+                new=AsyncMock(return_value=None),
+            ),
+            patch(
+                "custom_components.rain_incoming.coordinator.cloud_fraction_in_window",
+            ) as mock_cloud_fraction,
+        ):
+            result = await coordinator._compute_satellite_multiplier(-33.7, 151.2, mock_session)
+
+        assert result == 1.0, f"Expected 1.0 on tile fetch failure, got {result}"
+        mock_cloud_fraction.assert_not_called()
+
+
+class TestCombinedMultiplier:
+    @pytest.mark.asyncio
+    async def test_uses_max_of_pop_and_satellite_multipliers(self):
+        """_async_update_data must take max(pop_mult, sat_mult) and pass it to _build_config.
+
+        With pop_mult=2.0 and sat_mult=3.0, the DetectorConfig handed to detect()
+        must carry pop_multiplier=3.0 - the larger of the two. (The field is
+        called `pop_multiplier` historically; semantically it's now the combined
+        confidence multiplier.)
+        """
+        fixed_now = datetime(2024, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+        coordinator = _make_coordinator(
+            extra_data={
+                CONF_FORECAST_CONFIDENCE_ENABLED: True,
+                CONF_SATELLITE_CONFIDENCE_ENABLED: True,
+            }
+        )
+        frame = _make_frame(fixed_now)
+
+        captured_configs = []
+
+        def _capture_detect(**kwargs):
+            captured_configs.append(kwargs["config"])
+            return _EMPTY_RESULT
+
+        with (
+            patch.object(coordinator._provider, "get_frames", new=AsyncMock(return_value=[frame])),
+            patch.object(coordinator._provider, "prefetch_frames", new=AsyncMock()),
+            patch("custom_components.rain_incoming.coordinator.async_get_clientsession", return_value=MagicMock()),
+            patch.object(
+                coordinator, "_compute_pop_multiplier",
+                new=AsyncMock(return_value=2.0),
+            ),
+            patch.object(
+                coordinator, "_compute_satellite_multiplier",
+                new=AsyncMock(return_value=3.0),
+            ),
+            patch("custom_components.rain_incoming.coordinator.detect", side_effect=_capture_detect),
+        ):
+            await coordinator._async_update_data()
+
+        assert len(captured_configs) == 1, "detect() was not called"
+        assert captured_configs[0].pop_multiplier == 3.0, (
+            f"Expected combined multiplier 3.0 (max of pop=2.0 and sat=3.0), "
+            f"got {captured_configs[0].pop_multiplier}. "
+            "_async_update_data is not taking the max of the two multipliers."
+        )
 
 
 class TestBuildConfigUsesPopMultiplier:


### PR DESCRIPTION
## Summary

- Adds `providers/himawari.py`: fetches Himawari Band 13 Clean IR tiles from NASA GIBS (no auth required, 10-min cadence at zoom 6). Returns `IRTile` dataclass with 256×256 RGBA pixels.
- Adds `cloud_fraction_in_window()`: computes the fraction of pixels within `radius_km` of the location whose luminance ≥ threshold. At threshold 120 this correctly discriminates clear sky (luminance 0–127 range means overcast ≈ bright, clear ≈ dark).
- Adds `cloud_to_threshold_multiplier()` in `radar/confidence.py`: clear sky (fraction < 10%) → 3× multiplier; clouds present → 1.0. Mirrors PoP multiplier asymmetry from Phase 5A.
- Wires satellite multiplier into coordinator: `max(pop_mult, sat_mult)` so the stronger confidence signal always wins. New `_compute_satellite_multiplier()` method mirrors `_compute_pop_multiplier`.
- OptionsFlow toggle `enable_satellite_confidence` (default off). Persists in `entry.data`.

## New constants

| Constant | Value | Purpose |
|---|---|---|
| `GIBS_HIMAWARI_URL` | NASA GIBS template | Tile fetch URL |
| `GIBS_HIMAWARI_ZOOM` | 6 | Max zoom for this layer |
| `SATELLITE_CHECK_RADIUS_KM` | 50 | Window radius around location |
| `SATELLITE_CLOUD_BRIGHTNESS_THRESHOLD` | 120 | Luminance cutoff (0–255) |
| `SATELLITE_CLOUD_PRESENCE_FRACTION` | 0.1 | Fraction above which clouds are "present" |
| `CONF_SATELLITE_CONFIDENCE_ENABLED` | `"satellite_confidence_enabled"` | OptionsFlow key |

## Test plan

- [ ] Unit: `tests/unit/providers/test_himawari.py` — fetch happy path, HTTP error → None + WARNING, malformed PNG → None + WARNING, cloud fraction all-bright/all-dark/boundary/mixed
- [ ] Unit: `tests/unit/radar/test_confidence.py` — `cloud_to_threshold_multiplier` 6 parametrized boundary cases
- [ ] Unit: `tests/unit/test_coordinator.py` — satellite multiplier enabled/disabled/tile-None, combined max multiplier
- [ ] Integration: `tests/integration/test_config_flow.py` — OptionsFlow satellite toggle persists
- [ ] 676 tests pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)