### PR TITLE
backtest: add --pop-multiplier flag for PoP sensitivity analysis

### DIFF
--- a/docs/backtest-investigations.md
+++ b/docs/backtest-investigations.md
@@ -299,8 +299,23 @@ high-speed tracks. The downstream speed cap catches them but they consume
 detector cycles. Could pre-filter at the matching step or expose the
 post-evaluation rejection in Tier 0 to make the noise visible.
 
-## Framework Improvements Done
+## What's Actually Shipped (as of 2026-04-28)
 
+All items below are in production on `main`. The plan doc was stale.
+
+**Detection algorithm:**
+- [x] 3A: Default lookahead reduced 60→30min (PR #158)
+- [x] 3B: Frame-scaled min_frames - tested, NEUTRAL, kept as opt-in `--frame-scale-by-lookahead`
+- [x] 3C: Overhead immediate detection - already implemented via `_check_rain_at_location`. Fires `rain_incoming=True` in a single frame when rain pixels are within the proximity radius. Gated by QC confidence (warm clutter map suppresses false positives). No further work needed.
+- [x] 6A: Intensity trend filter - tested, NEUTRAL, REMOVED (opt-in `--use-intensity-trend` kept in backtest only)
+- [x] Leading-edge arrival fallback (PR #169) - for large incoherent storm fronts whose centroid zigzags while edge approaches. Fixes Perth false negative 2026-04-27 class of events.
+
+**Confidence signals:**
+- [x] 5A: Forecast PoP (Open-Meteo, hourly, no API key). Multiplier: PoP<5% → 3x, PoP<30% → 2x, PoP≥30% → 1.0, missing → 1.0 (fail open).
+  - **Open question**: the 3x multiplier at PoP<5% may be too aggressive for live use given hourly forecast lag. A stale "dry" forecast could suppress a real detection. Investigation: add `--pop-multiplier` to backtest CLI and run at 1.0/2.0/3.0 to bound the effect. Likely fix: soften to 1.5x/1.0x, or restrict gating to cells >50km away (hourly forecast has time to update before a distant cell arrives).
+- [x] 5B: Satellite IR cloud confidence (PR #165). Himawari/GOES via RealEarth tiles. Clear sky → 3x multiplier. Missing satellite → 1.0 (fail open).
+
+**Tooling:**
 - [x] Compare feature (`--compare`)
 - [x] Curated subset selection (`--generate-subset`, `--subset`)
 - [x] Tile decode optimisation (15ms → 1.2ms)
@@ -308,10 +323,13 @@ post-evaluation rejection in Tier 0 to make the noise visible.
 - [x] Frame caching in replay and verifier
 - [x] Tier 0 diagnostic trace (`--inspect LOCATION TIMESTAMP`)
 - [x] Tier 1 multi-window inspect (`--inspect-set MANIFEST`)
-- [x] `--use-intensity-trend` flag (Phase 6A, neutral effect)
-- [x] `--frame-scale-by-lookahead` flag (Phase 3B, unvalidated)
+- [x] `--inspect-session SESSION_DIR` for golden_v2 fixtures (PR #170, GH #164)
+- [x] `capture_golden_tiles.py --output-dir` for field captures (PR #170)
 
 ## Framework Improvements Remaining
+
+### `--pop-multiplier` flag for backtest
+Needed to run PoP sensitivity analysis. Add float flag (default 1.0) to the backtest CLI, thread into `_build_detector_config`. Run at 1.0/2.0/3.0 and compare scorecards to bound the live-cadence risk.
 
 ### Dry window skip
 Consecutive dry windows with unchanged latest frame produce identical detection results. Skip detection when the new frame is also dry - major speedup for locations with long dry periods.

--- a/scripts/backtest/cli.py
+++ b/scripts/backtest/cli.py
@@ -89,6 +89,8 @@ def _build_replay_config(args: argparse.Namespace) -> ReplayConfig:
         kwargs["min_cell_area_pixels"] = args.min_cell_area
     if args.use_acceleration:
         kwargs["use_acceleration"] = True
+    if args.pop_multiplier is not None:
+        kwargs["pop_multiplier"] = args.pop_multiplier
     return ReplayConfig(**kwargs)
 
 
@@ -178,6 +180,12 @@ def main(argv: list[str] | None = None) -> None:
         type=int,
         default=None,
         help="Override the minimum cell area in pixels for detection (default: production value)",
+    )
+    parser.add_argument(
+        "--pop-multiplier",
+        type=float,
+        default=None,
+        help="Override the PoP threshold multiplier (1.0=no effect, 2.0=moderate skepticism, 3.0=aggressive). Default: 1.0.",
     )
     parser.add_argument(
         "--use-acceleration",

--- a/scripts/backtest/replay.py
+++ b/scripts/backtest/replay.py
@@ -75,6 +75,7 @@ class ReplayConfig:
     intensity_threshold: float = INTENSITY_THRESHOLD
     min_cell_area_pixels: int = MIN_CELL_AREA_PIXELS
     use_acceleration: bool = False
+    pop_multiplier: float = 1.0
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +115,7 @@ def _build_detector_config(
         grid_width=grid_size,
         grid_height=grid_size,
         use_acceleration=replay_config.use_acceleration,
+        pop_multiplier=replay_config.pop_multiplier,
     )
 
 

--- a/tests/unit/backtest/test_cli.py
+++ b/tests/unit/backtest/test_cli.py
@@ -1021,3 +1021,58 @@ class TestInspectSession:
         assert exc_info.value.code == 1
         captured = capsys.readouterr()
         assert "no captures" in captured.err.lower() or "error" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
+# Test: --pop-multiplier overrides the pop_multiplier in ReplayConfig
+# ---------------------------------------------------------------------------
+
+
+class TestPopMultiplierFlag:
+    def test_pop_multiplier_passed_to_replay_config(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """--pop-multiplier passes the value into ReplayConfig.pop_multiplier."""
+        from scripts.backtest.cli import main
+
+        data_dir = tmp_path / "data"
+        captures_dir = data_dir / "captures"
+        _make_location_dir(captures_dir, "loc1")
+
+        predictions = [_make_prediction()]
+
+        with patch("scripts.backtest.cli.ReplayEngine") as MockEngine, \
+             patch("scripts.backtest.cli.ReplayConfig") as MockConfig:
+            MockConfig.return_value = MagicMock()
+            instance = MockEngine.return_value
+            instance.replay.return_value = predictions
+
+            main(["--data-dir", str(data_dir), "--pop-multiplier", "2.0"])
+
+        MockConfig.assert_called_once()
+        _, kwargs = MockConfig.call_args
+        assert kwargs.get("pop_multiplier") == pytest.approx(2.0)
+
+    def test_pop_multiplier_default_is_one(
+        self, tmp_path: Path, capsys
+    ) -> None:
+        """Without --pop-multiplier, pop_multiplier defaults to 1.0 (no effect)."""
+        from scripts.backtest.cli import main
+
+        data_dir = tmp_path / "data"
+        captures_dir = data_dir / "captures"
+        _make_location_dir(captures_dir, "loc1")
+
+        predictions = [_make_prediction()]
+
+        with patch("scripts.backtest.cli.ReplayEngine") as MockEngine, \
+             patch("scripts.backtest.cli.ReplayConfig") as MockConfig:
+            MockConfig.return_value = MagicMock()
+            instance = MockEngine.return_value
+            instance.replay.return_value = predictions
+
+            main(["--data-dir", str(data_dir)])
+
+        MockConfig.assert_called_once()
+        _, kwargs = MockConfig.call_args
+        assert kwargs.get("pop_multiplier", 1.0) == pytest.approx(1.0)


### PR DESCRIPTION
## Summary

- Adds `--pop-multiplier FLOAT` CLI flag to the backtest runner
- Threads the value through `ReplayConfig` → `_build_detector_config` → `DetectorConfig`
- Default is 1.0 (no effect on existing behaviour)
- Enables comparing detection accuracy at multiplier values 1.0 / 2.0 / 3.0 without touching production config
- Updates `docs/backtest-investigations.md`: corrects shipped-feature status and adds the live-cadence concern for 5A (PoP gating is only useful in production with live PoP data; backtest uses fixed multiplier)

## Test plan

- [x] `TestPopMultiplierFlag` - value threads through to `ReplayConfig`; default is 1.0
- [x] All 698 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)