### PR TITLE
chore: lower MIN_CELL_AREA_PIXELS from 4 to 1

### DIFF
--- a/custom_components/rain_incoming/const.py
+++ b/custom_components/rain_incoming/const.py
@@ -44,7 +44,12 @@ MIN_FRAMES_DEGRADED = 2
 
 # Detection thresholds
 INTENSITY_THRESHOLD = 0.1
-MIN_CELL_AREA_PIXELS = 4
+# Lowered from 4 to 1 (2026-05-04) after rain-incoming-backtester sweep on
+# 19-day full set: POD +3.6% mean across 7 active locations, with biggest
+# gains at coastal/METAR locations (hilo +8.4%, quillayute +7.3%, mobile
+# +4.8%) where sea-breeze convection produces small isolated cells. FAR
+# rose +24% mean - accepted per user preference of POD over FAR.
+MIN_CELL_AREA_PIXELS = 1
 MIN_TEMPORAL_FRAMES = 2
 MAX_ANGULAR_VARIANCE_RADIANS = 0.5
 MAX_STORM_SPEED_KMH = 120.0


### PR DESCRIPTION
## Summary
Lower the detector's minimum cell area threshold from 4 to 1 pixel.

Validated by [rain-incoming-backtester](https://github.com/abrainwood/rain-incoming-backtester) sweep on a 19-day full backtest (8 locations, 2343 windows each):

| Location | Baseline POD | New POD | Δ | Baseline FAR | New FAR | Δ |
|---|---|---|---|---|---|---|
| cairns_babinda | 0.953 | **0.960** | +0.7% | 0.052 | 0.054 | +0.2% |
| darwin | 0.835 | **0.857** | +2.6% | 0.367 | 0.376 | +0.9% |
| hilo | 0.843 | **0.914** | **+8.4%** | 0.083 | 0.179 | +9.6% |
| lake_margaret | 0.909 | 0.913 | +0.4% | 0.071 | 0.074 | +0.3% |
| mobile | 0.807 | **0.846** | +4.8% | 0.139 | 0.223 | +8.4% |
| penrith | 0.511 | 0.511 | 0% | 0.411 | 0.426 | +1.5% |
| quillayute | 0.794 | **0.852** | **+7.3%** | 0.154 | 0.260 | +10.6% |

**Mean across 7 active locations**: POD +3.6%, FAR +24%, CSI -1.9%.

Biggest gains at coastal METAR locations (hilo, quillayute, mobile) where sea-breeze convection produces small isolated cells that area=4 was filtering as noise. FAR cost accepted per the user-stated POD-over-FAR preference.

Sweep also tested area=1, 2, 6, 8, 10 on the quick-v3 (290-window) subset; quick-v3 confirmed area=1 wins for POD before validating on the full set.

## Test plan
- [x] 444 unit tests pass locally
- [x] 113 integration tests pass locally
- [x] `test_perth_golden` regression guard still asserts `rain_incoming=True` (more sensitive detector preserves it)
- [x] CI passes