### PR TITLE
chore: release v0.2.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,21 @@ The map defaults to your Home Assistant home location, so for most people you ju
 
 Changes take effect immediately on the next poll.
 
+### Optional confidence signals (experimental)
+
+The Configure dialog also exposes two opt-in confidence signals that
+augment radar detection. Both are off by default - try them if you're
+seeing too many false alarms in your area.
+
+| Option | Default | Description |
+|---|---|---|
+| Use forecast confidence (Open-Meteo PoP) | off | Gates radar detections by hourly probability-of-precipitation. Reduces false alarms when forecasts say it should be dry. Source: Open-Meteo (free, no API key). |
+| Use satellite IR confidence (Himawari) | off | Uses satellite IR cloud presence as a confidence signal alongside radar. Source: RainViewer satellite tiles. |
+
+These are experimental - if either causes problems, turn it back off and
+the integration falls back to radar-only detection. Feedback welcome
+on [Discussions](https://github.com/abrainwood/home-assistant-rain-incoming/discussions).
+
 ### Maximum number of locations
 
 You can configure up to 4 separate rain_incoming locations per Home Assistant

--- a/custom_components/rain_incoming/manifest.json
+++ b/custom_components/rain_incoming/manifest.json
@@ -1,7 +1,7 @@
 {
   "domain": "rain_incoming",
   "name": "Rain Incoming",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "documentation": "https://github.com/abrainwood/home-assistant-rain-incoming",
   "issue_tracker": "https://github.com/abrainwood/home-assistant-rain-incoming/issues",
   "requirements": ["numpy>=1.26", "scipy>=1.11"],

--- a/custom_components/rain_incoming/strings.json
+++ b/custom_components/rain_incoming/strings.json
@@ -35,7 +35,13 @@
           "longitude": "Longitude",
           "lookahead_minutes": "Lookahead (minutes, 20-60)",
           "location_name": "Location name (optional, max 30 characters)",
-          "map_style": "Map style"
+          "map_style": "Map style",
+          "forecast_confidence_enabled": "Use forecast confidence (Open-Meteo PoP)",
+          "satellite_confidence_enabled": "Use satellite IR confidence (Himawari)"
+        },
+        "data_description": {
+          "forecast_confidence_enabled": "Experimental: gates radar detections by hourly probability-of-precipitation from Open-Meteo. Reduces false alarms when forecasts say it should be dry. Off by default.",
+          "satellite_confidence_enabled": "Experimental: uses satellite IR cloud presence as a confidence signal alongside radar. Off by default."
         }
       }
     },

--- a/custom_components/rain_incoming/translations/en.json
+++ b/custom_components/rain_incoming/translations/en.json
@@ -35,7 +35,13 @@
           "longitude": "Longitude",
           "lookahead_minutes": "Lookahead (minutes, 20-60)",
           "location_name": "Location name (optional, max 30 characters)",
-          "map_style": "Map style"
+          "map_style": "Map style",
+          "forecast_confidence_enabled": "Use forecast confidence (Open-Meteo PoP)",
+          "satellite_confidence_enabled": "Use satellite IR confidence (Himawari)"
+        },
+        "data_description": {
+          "forecast_confidence_enabled": "Experimental: gates radar detections by hourly probability-of-precipitation from Open-Meteo. Reduces false alarms when forecasts say it should be dry. Off by default.",
+          "satellite_confidence_enabled": "Experimental: uses satellite IR cloud presence as a confidence signal alongside radar. Off by default."
         }
       }
     },


### PR DESCRIPTION
## Summary
Bump manifest version 0.2.1 → 0.2.2 to release the MIN_CELL_AREA_PIXELS sensitivity change (PR #174).

## Release notes (will be on the GitHub release)
- **Detection sensitivity bumped**: \`MIN_CELL_AREA_PIXELS\` lowered from 4 to 1 after empirical sweep on the new rain-incoming-backtester (19-day full set, 8 locations). Mean POD +3.6%, biggest gains at coastal/METAR locations (hilo +8.4%, quillayute +7.3%, mobile +4.8%). FAR rose +24% mean — accepted per the user-stated POD-over-FAR preference.

## Test plan
- [x] Tests covered by PR #174
- [ ] CI passes