### PR TITLE
chore: scaffold agent skills config (CONTEXT.md, ADRs, docs/agents/)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,3 +183,17 @@ Assume external dependencies will break. Code must be resilient and observable.
 ## Handling unknowns
 
 LLMs are naturally optimistic - bias toward pessimism. If you're unsure about something, say so. If you can verify quickly, do it. If you can't, stop and ask rather than silently assume.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub issues at `abrainwood/home-assistant-rain-incoming` (public). Cross-routing with the private `abrainwood/rain-incoming-backtester` is documented inline. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`) — labels exist on the repo with the same names. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` at the root, ADRs in `docs/adr/`. See `docs/agents/domain.md`.

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,15 @@
+# Context: rain_incoming
+
+Home Assistant custom integration that detects approaching rain from RainViewer radar tiles and exposes binary + arrival-time sensors for HA automations.
+
+## Glossary
+
+_(empty — populated lazily by `/grill-with-docs` as terms get resolved during planning sessions)_
+
+<!--
+Add terms here as they're resolved. Suggested format:
+
+### TermName
+
+What it means in this codebase. Note any synonyms the codebase **avoids**, so future agents and contributors don't drift back to them.
+-->

--- a/docs/adr/0001-record-architecture-decisions.md
+++ b/docs/adr/0001-record-architecture-decisions.md
@@ -1,0 +1,25 @@
+# 1. Record architecture decisions
+
+Date: 2026-05-05
+
+## Status
+
+Accepted
+
+## Context
+
+We need a lightweight, durable way to record the architectural decisions made on this project — the kind of decisions that are hard to reverse and that future contributors (and AI agents) need to understand without re-deriving the reasoning from code.
+
+## Decision
+
+We will record architectural decisions as ADRs (Architecture Decision Records) using the format described by Michael Nygard in [Documenting Architecture Decisions](https://cognitect.com/blog/2011/11/15/documenting-architecture-decisions).
+
+ADRs live in `docs/adr/` as numbered markdown files (`NNNN-title-in-kebab-case.md`). Each ADR has: Status, Context, Decision, Consequences.
+
+The `improve-codebase-architecture`, `diagnose`, and `tdd` skills read this directory before proposing changes in the affected area, and surface ADR conflicts explicitly rather than silently overriding them.
+
+## Consequences
+
+- Future architectural changes write a new ADR rather than amending the code-only.
+- Decisions are searchable in plain text; no external tool dependency.
+- A reader can reconstruct the design rationale by reading `docs/adr/` in order.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+This is a single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-record-architecture-decisions.md
+│   └── ...
+└── custom_components/rain_incoming/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-NNNN (title) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,30 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for the **rain_incoming Home Assistant integration** live as GitHub issues at `abrainwood/home-assistant-rain-incoming` (public). Use the `gh` CLI for all operations.
+
+## Repo routing
+
+This repo has a **sister repo**: `abrainwood/rain-incoming-backtester` (private). Route issues by subject:
+
+- **Integration concerns** (detection, QC, sensors, HA wiring, rendering, providers, config flow): file in `abrainwood/home-assistant-rain-incoming` (this repo).
+- **Backtester concerns** (replay engine, verifier, capture collector, sweep scripts, manifest tooling, observation correlation): file in `abrainwood/rain-incoming-backtester`.
+- **Issues that touch both** (e.g. an integration change driven by a backtest result): file in the integration repo and link the backtester counterpart with `abrainwood/rain-incoming-backtester#nnn`.
+
+Always confirm `git remote -v` before creating an issue — `gh` infers the repo from the cwd, so being in the wrong clone silently posts to the wrong tracker.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue in the appropriate repo (see Repo routing above).
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Canonical role     | Label in this tracker | Meaning                                  |
+| ------------------ | --------------------- | ---------------------------------------- |
+| `needs-triage`     | `needs-triage`        | Maintainer needs to evaluate this issue  |
+| `needs-info`       | `needs-info`          | Waiting on reporter for more information |
+| `ready-for-agent`  | `ready-for-agent`     | Fully specified, ready for an AFK agent  |
+| `ready-for-human`  | `ready-for-human`     | Requires human implementation            |
+| `wontfix`          | `wontfix`             | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

Scaffolds the per-repo configuration that the [Matt Pocock-style engineering agent skills](https://github.com/mattpocock/skills) assume — issue tracker, triage label vocabulary, and domain doc layout.

- `docs/agents/issue-tracker.md` — GitHub as the tracker plus a **cross-repo routing rule** with the private `rain-incoming-backtester` sister repo (so skills don't accidentally post backtester issues to this public repo).
- `docs/agents/triage-labels.md` — maps the five canonical triage roles (`needs-triage` / `needs-info` / `ready-for-agent` / `ready-for-human` / `wontfix`) to the labels that now exist on this repo.
- `docs/agents/domain.md` — tells skills how to consume `CONTEXT.md` and `docs/adr/`. Single-context layout.
- `CONTEXT.md` — stub glossary; populated lazily by `/grill-with-docs` as terms get resolved.
- `docs/adr/0001-record-architecture-decisions.md` — Nygard-style seed ADR.
- `CLAUDE.md` — new `## Agent skills` section pointing at the three `docs/agents/*.md` files.

Skills that read these: `to-issues`, `to-prd`, `triage`, `qa`, `improve-codebase-architecture`, `diagnose`, `tdd`, `zoom-out`, `grill-with-docs`.

## Test plan

- [x] Pre-commit hook ran the unit suite (444 passed)
- [x] Pre-push hook ran the test suite (113 passed)
- [ ] Verify `gh issue create --label needs-triage` etc. work against this repo (sanity check, not a regression risk)

🤖 Generated with [Claude Code](https://claude.com/claude-code)